### PR TITLE
enhance filename processing robustness

### DIFF
--- a/Script/addValueForAPI.py
+++ b/Script/addValueForAPI.py
@@ -8,6 +8,7 @@
 import sys
 import inspect
 import dill
+import hashlib
 
 ## @cond SCRIPT_ONLY
 ## Normalize file name
@@ -19,8 +20,11 @@ def getFileName(fileName,extension):
     fileName=fileName.replace('\\','')
     if len(extension) != 0:
         length=255-len(extension)
-        if len(fileName)>length:
-            fileName=fileName[0:length] #如果超出了长度，就进行截断
+        #if len(fileName)>length:
+            #fileName=fileName[0:length] #如果超出了长度，就进行截断
+        fileName=fileName.split('(')[0] + '_' + hashlib.md5(fileName.encode()).hexdigest()[:16] # 2025.7.18 More robust file name processing
+        fileName=fileName[0:length]
+
     fileName+=extension
     return fileName
 ## @endcond

--- a/Script/codeUtils.py
+++ b/Script/codeUtils.py
@@ -6,6 +6,7 @@
 ## Used by Preprocess/preprocess.py
 
 import dill
+import hashlib
 
 ## @cond SCRIPT_ONLY
 ## Normalize file name
@@ -17,8 +18,11 @@ def getFileName(fileName,extension):
     fileName=fileName.replace('\\','')
     if len(extension) != 0:
         length=255-len(extension)
-        if len(fileName)>length:
-            fileName=fileName[0:length] #如果超出了长度，就进行截断
+        #if len(fileName)>length:
+            #fileName=fileName[0:length] #如果超出了长度，就进行截断
+        fileName=fileName.split('(')[0] + '_' + hashlib.md5(fileName.encode()).hexdigest()[:16] # 2025.7.18 More robust file name processing
+        fileName=fileName[0:length]
+
     fileName+=extension 
     return fileName
 ## @endcond

--- a/Script/dynamicMatch.py
+++ b/Script/dynamicMatch.py
@@ -10,7 +10,7 @@ import json
 import inspect
 import copy
 import dill
-
+import hashlib
 
 ## @cond SCRIPT_ONLY
 ## Normalize file name 
@@ -22,8 +22,11 @@ def getFileName(fileName,extension):
     fileName=fileName.replace('\\','')
     if len(extension) != 0:
         length=255-len(extension)
-        if len(fileName)>length:
-            fileName=fileName[0:length] #如果超出了长度，就进行截断
+        #if len(fileName)>length:
+            #fileName=fileName[0:length] #如果超出了长度，就进行截断
+        fileName=fileName.split('(')[0] + '_' + hashlib.md5(fileName.encode()).hexdigest()[:16] # 2025.7.18 More robust file name processing
+        fileName=fileName[0:length]
+
     fileName+=extension 
     return fileName
 ## @endcond

--- a/Tool/tool.py
+++ b/Tool/tool.py
@@ -7,6 +7,7 @@ import re
 import os
 import ast
 import json
+import hashlib
 from Path.getPath import Path
 
 #将参数字符串拆分成单个的参数
@@ -360,8 +361,11 @@ def getFileName(fileName,extension):
     fileName=fileName.replace('\\','')
     if len(extension) != 0:
         length=255-len(extension)
-        if len(fileName)>length:
-            fileName=fileName[0:length] #如果超出了长度，就进行截断
+        #if len(fileName)>length:
+            #fileName=fileName[0:length] #如果超出了长度，就进行截断
+        fileName=fileName.split('(')[0] + '_' + hashlib.md5(fileName.encode()).hexdigest()[:16] # 2025.7.18 More robust file name processing
+        fileName=fileName[0:length]
+
     fileName+=extension 
     return fileName
     


### PR DESCRIPTION
Some test cases in PCBench (e.g., `sklearn/sklearn.neural_network.MLPRegressor@0.21.3-0.22/sklearn.neural_network.MLPRegressor#153YY`) have extremely long API names, leading to duplicated pkl filenames after filename processing. This pull request addresses this issue. 