### PR TITLE
Fix Windows path handling and runtime compatibility issues

### DIFF
--- a/Change/changeAnalyze.py
+++ b/Change/changeAnalyze.py
@@ -172,11 +172,11 @@ def isDifferType(oldType,newType):
             newType=newType[1:-1]
         
         if 'Union' in oldType:
-            pattern='.*?Union\[(.*)\].*?'
+            pattern=r'.*?Union\[(.*)\].*?'
             result=re.findall(pattern,oldType)
             oldLst=get_parameter(result[0])
         elif 'Optional' in oldType:
-            pattern='.*?Optional\[(.*)\].*?'
+            pattern=r'.*?Optional\[(.*)\].*?'
             result=re.findall(pattern,oldType)
             oldLst=get_parameter(result[0])
         elif '|' in oldType:
@@ -190,11 +190,11 @@ def isDifferType(oldType,newType):
 
 
         if 'Union' in newType:
-            pattern='.*?Union\[(.*)\].*?'
+            pattern=r'.*?Union\[(.*)\].*?'
             result=re.findall(pattern,newType)
             newLst=get_parameter(result[0])
         elif 'Optional' in newType:
-            pattern='.*?Optional\[(.*)\].*?'
+            pattern=r'.*?Optional\[(.*)\].*?'
             result=re.findall(pattern,newType)
             newLst=get_parameter(result[0])
         elif '|' in newType:
@@ -666,19 +666,19 @@ def addValueForAPI(callAPI,projName,runPath,runCommand,currentEnv,targetEnv,errL
         #     command=f'cd Dynamic/{projName};{pythonPath} {runPath}/addValueForAPI.py  "{pklStr}" "{callStr}"'
         if platform.system() == "Windows":
             if runPath not in runCommand:
-                command = f'cd Dynamic\\{projName}\\{runPath} && {pythonPath} addValueForAPI.py "{pklStr}" "{callStr}"'
+                command = f'cd "Dynamic\\{projName}\\{runPath}" && "{pythonPath}" addValueForAPI.py "{pklStr}" "{callStr}"'
             else:
-                command = f'cd Dynamic\\{projName} && {pythonPath} {runPath}\\addValueForAPI.py "{pklStr}" "{callStr}"'
+                command = f'cd "Dynamic\\{projName}" && "{pythonPath}" "{runPath}\\addValueForAPI.py" "{pklStr}" "{callStr}"'
         else:
             if runPath not in runCommand:
-                command = f'cd Dynamic/{projName}/{runPath};{pythonPath} addValueForAPI.py  "{pklStr}" "{callStr}"'
+                command = f'cd "Dynamic/{projName}/{runPath}";"{pythonPath}" addValueForAPI.py  "{pklStr}" "{callStr}"'
             else:
-                command = f'cd Dynamic/{projName};{pythonPath} {runPath}/addValueForAPI.py  "{pklStr}" "{callStr}"'
+                command = f'cd "Dynamic/{projName}";"{pythonPath}" "{runPath}/addValueForAPI.py"  "{pklStr}" "{callStr}"'
     else: #大部分属于这种情况
         if platform.system() == "Windows":
-            command=f'cd Dynamic\\{projName} && {pythonPath} addValueForAPI.py  "{pklStr}" "{callStr}"'
+            command=f'cd "Dynamic\\{projName}" && "{pythonPath}" addValueForAPI.py  "{pklStr}" "{callStr}"'
         else:
-            command=f'cd Dynamic/{projName};{pythonPath} addValueForAPI.py  "{pklStr}" "{callStr}"'
+            command=f'cd "Dynamic/{projName}";"{pythonPath}" addValueForAPI.py  "{pklStr}" "{callStr}"'
 
     # matchResult=subprocess.run(command,shell=True,executable='/bin/bash',stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True)
     matchResult = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)

--- a/Change/changeAnalyze.py
+++ b/Change/changeAnalyze.py
@@ -11,7 +11,7 @@ import re
 import copy
 import subprocess
 from API.LibApi import Parameter 
-from Tool.tool import get_parameter,removeParameter,getFileName
+from Tool.tool import get_parameter,removeParameter,getFileName,resolvePythonExecutable
 
 
 
@@ -649,17 +649,9 @@ def addValueForAPI(callAPI,projName,runPath,runCommand,currentEnv,targetEnv,errL
     
     # pythonPath=f"{virtualEnv}/bin/python"
     if flag==0:
-        # pythonPath=f"{currentEnv}/bin/python"
-        if platform.system() == "Windows":
-            pythonPath = os.path.join(currentEnv, "python.exe")
-        else:
-            pythonPath = f"{currentEnv}/bin/python"
+        pythonPath = resolvePythonExecutable(currentEnv)
     else:
-        # pythonPath=f"{targetEnv}/bin/python"
-        if platform.system() == "Windows":
-            pythonPath = os.path.join(targetEnv, "python.exe")
-        else:
-            pythonPath = f"{targetEnv}/bin/python"
+        pythonPath = resolvePythonExecutable(targetEnv)
     
     pklStr=pklPath.replace('"','\\"')
     callStr=callAPI.replace('"','\\"')

--- a/Change/changeAnalyze.py
+++ b/Change/changeAnalyze.py
@@ -642,7 +642,8 @@ def addValueForAPI(callAPI,projName,runPath,runCommand,currentEnv,targetEnv,errL
     #当runPath不在runCommand中时，需要切换到运行文件所在的目录执行命令
     #而文件操作的相对路径就是相对于命令执行的路径
     if runPath!='' and runPath not in runCommand:
-        l=len(runPath.split('/'))
+        normalized_runPath = runPath.replace('\\', '/').strip('/')
+        l=len([segment for segment in normalized_runPath.split('/') if segment])
         while l>0:
             pklPath='../'+pklPath
             l-=1

--- a/Map/map.py
+++ b/Map/map.py
@@ -19,7 +19,7 @@ from Preprocess.preprocess import addDictSingle
 
 
 ## Check the last name in an API call is an alias or not
-## 判断一个callAPI最后一个名字是否为库中的别名
+## 判断一个callAPI最后一个名字是否为库中的别�?
 #
 #  @param callApi The called API to be check
 #  @param assignDict The assign dict stores the alias of APIs
@@ -40,46 +40,46 @@ def isAlias(callApi,assignDict):
 
 
 ## Static mapping of API signatures
-## API签名静态匹配
+## API签名静态匹�?
 #
 #  @param formatAPI The called API
 #  @param libName The upgraded lib 
 #  @param version The upgraded lib's version 
 #  @param builtinFlag Built-in API flag
 #  @return ansDict Mapped API signatures 
-def fuzzymatch(formatAPI,libName,version,builtinFlag): #callAPIDict是传入传出参数
+def fuzzymatch(formatAPI,libName,version,builtinFlag): #callAPIDict是传入传出参�?
     libAPIs,assignDict,libAPIIns=loadLib(libName,version)
     Fuzz=fuzzyMatch()
     if builtinFlag and len(libAPIIns)>0:
-        ans=Fuzz.fmatch(formatAPI,libAPIIns) #只从.pyi文件里找,但如果没有注释的话,也不一定能找到，
+        ans=Fuzz.fmatch(formatAPI,libAPIIns) #只从.pyi文件里找,但如果没有注释的�?也不一定能找到�?
     else:
         ans=Fuzz.fmatch(formatAPI,libAPIs)
 
     if len(ans)==0 and not builtinFlag:
         aliasName=Fuzz.alias
-        realName=isAlias(aliasName,assignDict) #检查是否是别名，是的话就将别名还原成真名，然后再进行模糊匹配
+        realName=isAlias(aliasName,assignDict) #检查是否是别名，是的话就将别名还原成真名，然后再进行模糊匹�?
         if realName is not None: 
             ans=Fuzz.fmatch(realName,libAPIs)
     
-    #对匹配出的结果按照不同的函数名进行分类,得到一个形式为{同名:[重载]}字典
+    #对匹配出的结果按照不同的函数名进行分�?得到一个形式为{同名:[重载]}字典
     ansDict={}
     for it in ans: #ans是模糊得到的结果，当然也可能为空
         pos=it.find('(')
         if pos!=-1:
             apiName=it[0:pos]
             parameters=it[pos:]
-            if removeParameter(it)==formatAPI:#若和formatAPI完全相等，则说明匹配的结果是唯一且正确
+            if removeParameter(it)==formatAPI:#若和formatAPI完全相等，则说明匹配的结果是唯一且正�?
                 return {apiName:[parameters]}
             
             if apiName not in ansDict:
-                ansDict[apiName]=[] #初始化字典，把同一个API的不同重载放到一起
+                ansDict[apiName]=[] #初始化字典，把同一个API的不同重载放到一�?
             ansDict[apiName].append(parameters)
     return ansDict 
 
 
 
 ## Dynamic mapping of API signatures
-## API签名动态匹配 
+## API签名动态匹�?
 #
 #  @param callAPI The called API
 #  @param runCommand The run command of the project
@@ -119,24 +119,24 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
     #         command=f'cd Dynamic/{projName}/{runPath};{pythonPath} dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
     #     else:
     #         command=f'cd Dynamic/{projName};{pythonPath} {runPath}/dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
-    # else: #大部分属于这种情况
+    # else: #大部分属于这种情�?
     #     command=f'cd Dynamic/{projName};{pythonPath} dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
     if platform.system() == "Windows":
         if runPath != '':
             if runPath not in runCommand:
-                command = f'cd Dynamic\\{projName}\\{runPath} && {pythonPath} dynamicMatch.py "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
+                command = f'cd "Dynamic\\{projName}\\{runPath}" && "{pythonPath}" dynamicMatch.py "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
             else:
-                command = f'cd Dynamic\\{projName} && {pythonPath} {runPath}\\dynamicMatch.py "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
+                command = f'cd "Dynamic\\{projName}" && "{pythonPath}" "{runPath}\\dynamicMatch.py" "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
         else:
-            command = f'cd Dynamic\\{projName} && {pythonPath} dynamicMatch.py "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
+            command = f'cd "Dynamic\\{projName}" && "{pythonPath}" dynamicMatch.py "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
     else:
         if runPath != '':
             if runPath not in runCommand:
-                command = f'cd Dynamic/{projName}/{runPath};{pythonPath} dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
+                command = f'cd "Dynamic/{projName}/{runPath}";"{pythonPath}" dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
             else:
-                command = f'cd Dynamic/{projName};{pythonPath} {runPath}/dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
+                command = f'cd "Dynamic/{projName}";"{pythonPath}" "{runPath}/dynamicMatch.py" "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
         else:
-            command = f'cd Dynamic/{projName};{pythonPath} dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
+            command = f'cd "Dynamic/{projName}";"{pythonPath}" dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
 
     # matchResult=subprocess.run(command,shell=True,executable='/bin/bash',stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True)
     matchResult = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
@@ -153,37 +153,37 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
             errLst.append(f"{callAPI}, Failed to load pkl in current version{version}: {matchResult.stderr}\n") 
             return False
         
-        #若在新版本中无法加载旧版本的pkl文件，则尝试在新版本中重新生成
+        #若在新版本中无法加载旧版本的pkl文件，则尝试在新版本中重新生�?
         #什么情况下不需要在目标版本重新生成？什么情况下需要在mu
         # elif 'Ran out of input' not in matchResult.stderr:
         elif stderr and 'Ran out of input' not in stderr:
             loadError=f"{callAPI}, Failed to load pkl in target version{version}: {matchResult.stderr}\n" 
             with lock:
                 shutil.copy2(copyFile,f"{copyFile}.bak")
-                addDictSingle(callAPI,copyFile) #添加字典并运行，在当前文件中添加字典，在运行文件中
-                pklFile='new_'+pklFile #更新pkl文件名
+                addDictSingle(callAPI,copyFile) #添加字典并运行，在当前文件中添加字典，在运行文件�?
+                pklFile='new_'+pklFile #更新pkl文件�?
                 if platform.system() == "Windows":
                     if runPath in runCommand:
-                        command=f'cd Copy\\{projName} && {pythonPath} {runCommand}'
+                        command=f'cd "Copy\\{projName}" && "{pythonPath}" {runCommand}'
                     else:
-                        command=f'cd Copy\\{projName}\\{runPath} && {pythonPath} {runCommand}'
+                        command=f'cd "Copy\\{projName}\\{runPath}" && "{pythonPath}" {runCommand}'
                 else:
                     if runPath in runCommand:
-                        command=f'cd Copy/{projName};{pythonPath} {runCommand};' #运行项目指令的时候需要考虑运行文件目录是否已经包含到runCommand中了
+                        command=f'cd "Copy/{projName}";"{pythonPath}" {runCommand};' #运行项目指令的时候需要考虑运行文件目录是否已经包含到runCommand中了
                     else:
-                        command=f'cd Copy/{projName}/{runPath};{pythonPath} {runCommand};'
+                        command=f'cd "Copy/{projName}/{runPath}";"{pythonPath}" {runCommand};'
                 # generateResult=subprocess.run(command,shell=True,executable='/bin/bash',stderr=subprocess.PIPE,text=True)
                 generateResult = subprocess.run(command, shell=True, stderr=subprocess.PIPE, text=True)
                 if generateResult.returncode==0:
                     pklStr=pklFile.replace('"','\\"')
                     if platform.system() == "Windows":
-                        command=f'cd Copy\\pkl && move paraValue.pkl "{pklStr}"'
+                        command=f'cd "Copy\\pkl" && move paraValue.pkl "{pklStr}"'
                     else:
-                        command=f'cd Copy/pkl;mv paraValue.pkl "{pklStr}"'
+                        command=f'cd "Copy/pkl";mv paraValue.pkl "{pklStr}"'
                     # subprocess.run(command,shell=True,executable='/bin/bash',stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True)
                     subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
             
-                #插桩完后，再将备份后的文件进行还原
+                #插桩完后，再将备份后的文件进行还�?
                 os.remove(copyFile)
                 shutil.move(f'{copyFile}.bak',copyFile)
         
@@ -195,19 +195,19 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
                 if runPath!='':
                     if runPath not in runCommand:#需要切换到运行文件所在的目录执行命令
                         if platform.system() == "Windows":
-                            command=f'cd Dynamic\\{projName}\\{runPath} && {pythonPath} dynamicMatch.py "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
+                            command=f'cd "Dynamic\\{projName}\\{runPath}" && "{pythonPath}" dynamicMatch.py "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
                         else:
-                            command=f'cd Dynamic/{projName}/{runPath};{pythonPath} dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
+                            command=f'cd "Dynamic/{projName}/{runPath}";"{pythonPath}" dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
                     else:
                         if platform.system() == "Windows":
-                            command=f'cd Dynamic\\{projName} && {pythonPath} {runPath}\\dynamicMatch.py "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
+                            command=f'cd "Dynamic\\{projName}" && "{pythonPath}" "{runPath}\\dynamicMatch.py" "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
                         else:
-                            command=f'cd Dynamic/{projName};{pythonPath} {runPath}/dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
-                else: #大部分属于这种情况
+                            command=f'cd "Dynamic/{projName}";"{pythonPath}" "{runPath}/dynamicMatch.py" "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
+                else: #大部分属于这种情�?
                     if platform.system() == "Windows":
-                        command=f'cd Dynamic\\{projName} && {pythonPath} dynamicMatch.py "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
+                        command=f'cd "Dynamic\\{projName}" && "{pythonPath}" dynamicMatch.py "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
                     else:
-                        command=f'cd Dynamic/{projName};{pythonPath} dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
+                        command=f'cd "Dynamic/{projName}";"{pythonPath}" dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
                 # matchResult=subprocess.run(command,shell=True,executable='/bin/bash',stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True)
                 matchResult = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
                 if matchResult.returncode!=0:
@@ -237,10 +237,10 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
 
 
 ## Construct the mapping between the invoked API and the lib API to obtain its signature 
-## 建立invoked API与 lib API之间的映射关系，从而获取其参数定义
+## 建立invoked API�?lib API之间的映射关系，从而获取其参数定义
 #
 #  先进行动态匹配，动态匹配的结果是保存在api_dynamic.json文件中的
-#  动态匹配的成功包括3步：1.加载PKL； 2.动态脚本执行成功，3.动态获取参数成功（部分内置api无法获取参数）
+#  动态匹配的成功包括3步：1.加载PKL�?2.动态脚本执行成功，3.动态获取参数成功（部分内置api无法获取参数�?
 #
 #  @param callAPI The called API
 #  @param runCommand The run command of the project
@@ -258,7 +258,7 @@ def mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,versio
     dynamicMatchDict=dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv,lock,errLst,curr)
     ans={}
     ans['format']=formatAPI
-    if dynamicMatchDict!=False: #若动态匹配成功,还要对动态匹配的结果进行检查
+    if dynamicMatchDict!=False: #若动态匹配成�?还要对动态匹配的结果进行检�?
         result=dynamicMatchDict['match']
         ans['error']=dynamicMatchDict['error']
         if 'internalPath' in dynamicMatchDict:
@@ -267,7 +267,7 @@ def mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,versio
             ans['internalPath']=formatAPI 
     
         if 'builtin' in dynamicMatchDict['error']: #这里的内置不一定是库的内置，有可能是python内置,如何区分?
-            ans['match']=fuzzymatch(formatAPI,libName,version,1) #目前只发现pytorch中把内置记录到了.pyi中
+            ans['match']=fuzzymatch(formatAPI,libName,version,1) #目前只发现pytorch中把内置记录到了.pyi�?
             ans['matchMethod']='static'
         elif result=='nullptr': #若inspect失败
             ans['match']=fuzzymatch(formatAPI,libName,version,0)
@@ -280,3 +280,4 @@ def mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,versio
         ans['matchMethod']='static'
 
     return ans
+

--- a/Map/map.py
+++ b/Map/map.py
@@ -12,7 +12,7 @@ import subprocess
 import platform
 from Map.fuzzyMatch import *
 from Load.loadData import loadLib
-from Tool.tool import removeParameter,getFileName
+from Tool.tool import removeParameter,getFileName,resolvePythonExecutable
 from Extract.getCall import getCallFunction
 from Preprocess.preprocess import addDictSingle
 
@@ -94,10 +94,7 @@ def fuzzymatch(formatAPI,libName,version,builtinFlag): #callAPIDict是传入传�
 #  @return dynamicMatchDict Mapped API signatures 
 def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv,lock,errLst,curr=1):
     # pythonPath=f"{virtualEnv}/bin/python" #先指定python解释器的路径
-    if platform.system() == "Windows":
-        pythonPath = os.path.join(virtualEnv, "python.exe")
-    else:
-        pythonPath = f"{virtualEnv}/bin/python"
+    pythonPath = resolvePythonExecutable(virtualEnv)
     pklFile=getFileName(callAPI,'.pkl')
     pklStr=pklFile.replace('"','\\"')
     callStr=callAPI.replace('"','\\"')

--- a/Map/map.py
+++ b/Map/map.py
@@ -104,8 +104,8 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
     #当runPath不在runCommand中时，需要切换到运行文件所在的目录执行命令
     #而文件操作的相对路径就是相对于命令执行的路径
     if runPath!='' and runPath not in runCommand:
-        normalized_runPath = runPath.replace('\\', '/')
-        l=len(normalized_runPath.split('/'))
+        normalized_runPath = runPath.replace('\\', '/').strip('/')
+        l=len([segment for segment in normalized_runPath.split('/') if segment])
         while l>0:
             pklPrefix='../'+pklPrefix
             jsonPrefix='../'+jsonPrefix

--- a/Map/map.py
+++ b/Map/map.py
@@ -19,7 +19,7 @@ from Preprocess.preprocess import addDictSingle
 
 
 ## Check the last name in an API call is an alias or not
-## 判断一个callAPI最后一个名字是否为库中的别�?
+## 判断一个callAPI最后一个名字是否为库中的别名
 #
 #  @param callApi The called API to be check
 #  @param assignDict The assign dict stores the alias of APIs
@@ -40,46 +40,46 @@ def isAlias(callApi,assignDict):
 
 
 ## Static mapping of API signatures
-## API签名静态匹�?
+## API签名静态匹配
 #
 #  @param formatAPI The called API
 #  @param libName The upgraded lib 
 #  @param version The upgraded lib's version 
 #  @param builtinFlag Built-in API flag
 #  @return ansDict Mapped API signatures 
-def fuzzymatch(formatAPI,libName,version,builtinFlag): #callAPIDict是传入传出参�?
+def fuzzymatch(formatAPI,libName,version,builtinFlag): #callAPIDict是传入传出参数
     libAPIs,assignDict,libAPIIns=loadLib(libName,version)
     Fuzz=fuzzyMatch()
     if builtinFlag and len(libAPIIns)>0:
-        ans=Fuzz.fmatch(formatAPI,libAPIIns) #只从.pyi文件里找,但如果没有注释的�?也不一定能找到�?
+        ans=Fuzz.fmatch(formatAPI,libAPIIns) #只从.pyi文件里找,但如果没有注释的话,也不一定能找到，
     else:
         ans=Fuzz.fmatch(formatAPI,libAPIs)
 
     if len(ans)==0 and not builtinFlag:
         aliasName=Fuzz.alias
-        realName=isAlias(aliasName,assignDict) #检查是否是别名，是的话就将别名还原成真名，然后再进行模糊匹�?
+        realName=isAlias(aliasName,assignDict) #检查是否是别名，是的话就将别名还原成真名，然后再进行模糊匹配
         if realName is not None: 
             ans=Fuzz.fmatch(realName,libAPIs)
     
-    #对匹配出的结果按照不同的函数名进行分�?得到一个形式为{同名:[重载]}字典
+    #对匹配出的结果按照不同的函数名进行分类,得到一个形式为{同名:[重载]}字典
     ansDict={}
     for it in ans: #ans是模糊得到的结果，当然也可能为空
         pos=it.find('(')
         if pos!=-1:
             apiName=it[0:pos]
             parameters=it[pos:]
-            if removeParameter(it)==formatAPI:#若和formatAPI完全相等，则说明匹配的结果是唯一且正�?
+            if removeParameter(it)==formatAPI:#若和formatAPI完全相等，则说明匹配的结果是唯一且正确
                 return {apiName:[parameters]}
             
             if apiName not in ansDict:
-                ansDict[apiName]=[] #初始化字典，把同一个API的不同重载放到一�?
+                ansDict[apiName]=[] #初始化字典，把同一个API的不同重载放到一起
             ansDict[apiName].append(parameters)
     return ansDict 
 
 
 
 ## Dynamic mapping of API signatures
-## API签名动态匹�?
+## API签名动态匹配 
 #
 #  @param callAPI The called API
 #  @param runCommand The run command of the project
@@ -116,11 +116,11 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
 
     # if runPath!='':
     #     if runPath not in runCommand:
-    #         command=f'cd Dynamic/{projName}/{runPath};{pythonPath} dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
+    #         command=f'cd "Dynamic/{projName}/{runPath}";"{pythonPath}" dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
     #     else:
-    #         command=f'cd Dynamic/{projName};{pythonPath} {runPath}/dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
-    # else: #大部分属于这种情�?
-    #     command=f'cd Dynamic/{projName};{pythonPath} dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
+    #         command=f'cd "Dynamic/{projName}";"{pythonPath}" "{runPath}/dynamicMatch.py" "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
+    # else: #大部分属于这种情况
+    #     command=f'cd "Dynamic/{projName}";"{pythonPath}" dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
     if platform.system() == "Windows":
         if runPath != '':
             if runPath not in runCommand:
@@ -153,15 +153,15 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
             errLst.append(f"{callAPI}, Failed to load pkl in current version{version}: {matchResult.stderr}\n") 
             return False
         
-        #若在新版本中无法加载旧版本的pkl文件，则尝试在新版本中重新生�?
+        #若在新版本中无法加载旧版本的pkl文件，则尝试在新版本中重新生成
         #什么情况下不需要在目标版本重新生成？什么情况下需要在mu
         # elif 'Ran out of input' not in matchResult.stderr:
         elif stderr and 'Ran out of input' not in stderr:
             loadError=f"{callAPI}, Failed to load pkl in target version{version}: {matchResult.stderr}\n" 
             with lock:
                 shutil.copy2(copyFile,f"{copyFile}.bak")
-                addDictSingle(callAPI,copyFile) #添加字典并运行，在当前文件中添加字典，在运行文件�?
-                pklFile='new_'+pklFile #更新pkl文件�?
+                addDictSingle(callAPI,copyFile) #添加字典并运行，在当前文件中添加字典，在运行文件中
+                pklFile='new_'+pklFile #更新pkl文件名
                 if platform.system() == "Windows":
                     if runPath in runCommand:
                         command=f'cd "Copy\\{projName}" && "{pythonPath}" {runCommand}'
@@ -183,7 +183,7 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
                     # subprocess.run(command,shell=True,executable='/bin/bash',stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True)
                     subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
             
-                #插桩完后，再将备份后的文件进行还�?
+                #插桩完后，再将备份后的文件进行还原
                 os.remove(copyFile)
                 shutil.move(f'{copyFile}.bak',copyFile)
         
@@ -203,7 +203,7 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
                             command=f'cd "Dynamic\\{projName}" && "{pythonPath}" "{runPath}\\dynamicMatch.py" "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
                         else:
                             command=f'cd "Dynamic/{projName}";"{pythonPath}" "{runPath}/dynamicMatch.py" "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
-                else: #大部分属于这种情�?
+                else: #大部分属于这种情况
                     if platform.system() == "Windows":
                         command=f'cd "Dynamic\\{projName}" && "{pythonPath}" dynamicMatch.py "{pklPrefix}\\Copy\\pkl\\{pklStr}" "{callStr}" "{jsonPrefix}"'
                     else:
@@ -237,10 +237,10 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
 
 
 ## Construct the mapping between the invoked API and the lib API to obtain its signature 
-## 建立invoked API�?lib API之间的映射关系，从而获取其参数定义
+## 建立invoked API与 lib API之间的映射关系，从而获取其参数定义
 #
 #  先进行动态匹配，动态匹配的结果是保存在api_dynamic.json文件中的
-#  动态匹配的成功包括3步：1.加载PKL�?2.动态脚本执行成功，3.动态获取参数成功（部分内置api无法获取参数�?
+#  动态匹配的成功包括3步：1.加载PKL； 2.动态脚本执行成功，3.动态获取参数成功（部分内置api无法获取参数）
 #
 #  @param callAPI The called API
 #  @param runCommand The run command of the project
@@ -258,7 +258,7 @@ def mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,versio
     dynamicMatchDict=dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv,lock,errLst,curr)
     ans={}
     ans['format']=formatAPI
-    if dynamicMatchDict!=False: #若动态匹配成�?还要对动态匹配的结果进行检�?
+    if dynamicMatchDict!=False: #若动态匹配成功,还要对动态匹配的结果进行检查
         result=dynamicMatchDict['match']
         ans['error']=dynamicMatchDict['error']
         if 'internalPath' in dynamicMatchDict:
@@ -267,7 +267,7 @@ def mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,versio
             ans['internalPath']=formatAPI 
     
         if 'builtin' in dynamicMatchDict['error']: #这里的内置不一定是库的内置，有可能是python内置,如何区分?
-            ans['match']=fuzzymatch(formatAPI,libName,version,1) #目前只发现pytorch中把内置记录到了.pyi�?
+            ans['match']=fuzzymatch(formatAPI,libName,version,1) #目前只发现pytorch中把内置记录到了.pyi中
             ans['matchMethod']='static'
         elif result=='nullptr': #若inspect失败
             ans['match']=fuzzymatch(formatAPI,libName,version,0)
@@ -280,4 +280,3 @@ def mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,versio
         ans['matchMethod']='static'
 
     return ans
-

--- a/Preprocess/preprocess.py
+++ b/Preprocess/preprocess.py
@@ -645,8 +645,8 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
         #当runPath不在runCommand中时，需要切换到运行文件所在的目录执行命令
         #而文件操作的相对路径就是相对于命令执行的路径
         if runPath!='' and runPath not in runCommand:
-            normalized_runPath = runPath.replace('\\', '/')
-            l=len(normalized_runPath.split('/'))
+            normalized_runPath = runPath.replace('\\', '/').strip('/')
+            l=len([segment for segment in normalized_runPath.split('/') if segment])
             while l>0:
                 pklPrefix='../'+pklPrefix
                 l-=1
@@ -781,8 +781,8 @@ def handleRunFile(file,runPath,runCommand):
     #而文件操作的相对路径就是相对于命令执行的路径
     pklPrefix=f"../../Copy/pkl"
     if runPath!='' and runPath not in runCommand:
-        normalized_runPath = runPath.replace('\\', '/')
-        l=len(normalized_runPath.split('/'))
+        normalized_runPath = runPath.replace('\\', '/').strip('/')
+        l=len([segment for segment in normalized_runPath.split('/') if segment])
         while l>0:
             pklPrefix='../'+pklPrefix
             l-=1

--- a/Repair/repair.py
+++ b/Repair/repair.py
@@ -9,7 +9,7 @@ import os
 import ast
 import platform
 import subprocess
-from Tool.tool import getAst,getFileName,get_parameter,getLastAPIParameter
+from Tool.tool import getAst,getFileName,get_parameter,getLastAPIParameter,resolvePythonExecutable
 from API.LibApi import Parameter
 from Change.changeAnalyze import para2Obj
 
@@ -284,10 +284,7 @@ def validateByRun(callAPI,apiWithValue,projName,virtualEnv,runPath,runCommand):
         while l>0:
             pklPath='../'+pklPath
             l-=1
-    if platform.system() == "Windows":
-        pythonPath = os.path.join(virtualEnv, "python.exe")
-    else:
-        pythonPath = f"{virtualEnv}/bin/python"
+    pythonPath = resolvePythonExecutable(virtualEnv)
 
     apiWithValue=apiWithValue.replace('"','\\"')
     pklPath=pklPath.replace('"','\\"')

--- a/Repair/repair.py
+++ b/Repair/repair.py
@@ -280,7 +280,8 @@ def validateByRun(callAPI,apiWithValue,projName,virtualEnv,runPath,runCommand):
     #当runPath不在runCommand中时，需要切换到运行文件所在的目录执行命令
     #而文件操作的相对路径就是相对于命令执行的路径
     if runPath!='' and runPath not in runCommand:
-        l=len(runPath.split('/'))
+        normalized_runPath = runPath.replace('\\', '/').strip('/')
+        l=len([segment for segment in normalized_runPath.split('/') if segment])
         while l>0:
             pklPath='../'+pklPath
             l-=1

--- a/Repair/repair.py
+++ b/Repair/repair.py
@@ -292,19 +292,19 @@ def validateByRun(callAPI,apiWithValue,projName,virtualEnv,runPath,runCommand):
     if runPath!='':
         if platform.system() == "Windows":
             if runPath not in runCommand:
-                command = f'cd Dynamic\\{projName}\\{runPath} && {pythonPath} verifySingle.py "{pklPath}" "{apiWithValue}"'
+                command = f'cd "Dynamic\\{projName}\\{runPath}" && "{pythonPath}" verifySingle.py "{pklPath}" "{apiWithValue}"'
             else:
-                command=f'cd Dynamic\\{projName} && {pythonPath} {runPath}\\verifySingle.py "{pklPath}" "{apiWithValue}"'
+                command=f'cd "Dynamic\\{projName}" && "{pythonPath}" "{runPath}\\verifySingle.py" "{pklPath}" "{apiWithValue}"'
         else:
             if runPath not in runCommand:#需要切换到运行文件所在的目录执行命令
-                command=f'cd Dynamic/{projName}/{runPath};{pythonPath} verifySingle.py "{pklPath}" "{apiWithValue}"'
+                command=f'cd "Dynamic/{projName}/{runPath}";"{pythonPath}" verifySingle.py "{pklPath}" "{apiWithValue}"'
             else:
-                command=f'cd Dynamic/{projName};{pythonPath} {runPath}/verifySingle.py "{pklPath}" "{apiWithValue}"'
+                command=f'cd "Dynamic/{projName}";"{pythonPath}" "{runPath}/verifySingle.py" "{pklPath}" "{apiWithValue}"'
     else: #大部分属于这种情况
         if platform.system() == "Windows":
-            command=f'cd Dynamic\\{projName} && {pythonPath} verifySingle.py "{pklPath}" "{apiWithValue}"'
+            command=f'cd "Dynamic\\{projName}" && "{pythonPath}" verifySingle.py "{pklPath}" "{apiWithValue}"'
         else:
-            command=f'cd Dynamic/{projName};{pythonPath} verifySingle.py "{pklPath}" "{apiWithValue}"'
+            command=f'cd "Dynamic/{projName}";"{pythonPath}" verifySingle.py "{pklPath}" "{apiWithValue}"'
     result=subprocess.run(command,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True)
     return result
 

--- a/Tool/tool.py
+++ b/Tool/tool.py
@@ -11,6 +11,8 @@ import ast
 import json
 import hashlib
 import platform
+import subprocess
+from functools import lru_cache
 from Path.getPath import Path
 
 
@@ -578,6 +580,43 @@ def findPythonDir(basePath):
     print(f"Can not find {basePath}/pythonxx.xx")
     return None
 
+
+## Resolve Python executable from a virtual environment root
+## 从虚拟环境根目录解析 Python 解释器路径
+#
+#  @param envPath The virtual environment root path
+#  @return resolvedPath Absolute path of the Python executable
+@lru_cache(maxsize=None)
+def resolvePythonExecutable(envPath):
+    normalizedEnvPath = os.path.abspath(envPath)
+    candidates = [
+        os.path.join(normalizedEnvPath, 'python.exe'),
+        os.path.join(normalizedEnvPath, 'Scripts', 'python.exe'),
+        os.path.join(normalizedEnvPath, 'bin', 'python'),
+        os.path.join(normalizedEnvPath, 'bin', 'python3'),
+    ]
+
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            command = [candidate, '-c', 'import sys; print(sys.version_info[0])']
+            try:
+                result = subprocess.run(
+                    command,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+            except Exception:
+                continue
+
+            if result.returncode == 0 and result.stdout.strip() == '3':
+                return candidate
+
+    candidate_str = ', '.join(candidates)
+    raise FileNotFoundError(
+        f"Cannot find Python 3 executable under virtual environment root: "
+        f"{normalizedEnvPath}. Tried: {candidate_str}"
+    )
 
 
 ## Get source code path of the lib 

--- a/main.py
+++ b/main.py
@@ -24,7 +24,6 @@ from Tool.tool import getAst,save2txt,loadConfig,removeParameter,getFileName,res
 from Change.changeAnalyze import isCompatible,addValueForAPI,updateSharedDict,querySharedDict,updateErrorLst
 
 
-
 ## One process handles one file 
 ## 一个进程处理一个文件
 #
@@ -164,6 +163,9 @@ def backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,
     pathObj.getPath(projPath)
     filePath=[it for it in pathObj.path if it.endswith('py')] #保留项目中的.py文件
     projName=os.path.basename(projPath)
+    errorLog = os.path.join('Report', f'{projName}_fixed_log.txt')
+    if os.path.exists(errorLog):
+        os.remove(errorLog)
     
     #先在起始版本中生成每个API的pkl
     # pythonPath=f"{currentEnv}/bin/python"

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ from multiprocessing import Manager
 from Extract.getCall import getCallFunction
 from Preprocess.preprocess import codeProcess
 from Repair.repair import repairTask,validateByRun
-from Tool.tool import getAst,save2txt,loadConfig,removeParameter,getFileName
+from Tool.tool import getAst,save2txt,loadConfig,removeParameter,getFileName,resolvePythonExecutable
 from Change.changeAnalyze import isCompatible,addValueForAPI,updateSharedDict,querySharedDict,updateErrorLst
 
 
@@ -172,11 +172,7 @@ def backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,
     # else: #针对于python run.py,但执行路径位于scr下,此处的runPath也可能为空
     #     command=f'cd Copy/{projName}/{runPath};{pythonPath}{runCommand}'
     # 1. python 路径自动适配
-    if platform.system() == 'Windows':
-        currentEnv = currentEnv.replace('/', '\\')
-        pythonPath = os.path.join(currentEnv, 'python.exe')
-    else:
-        pythonPath = os.path.join(currentEnv, 'bin', 'python')
+    pythonPath = resolvePythonExecutable(currentEnv)
     # 2. 运行命令自动适配
     if platform.system() == 'Windows':
         if runPath in runCommand:

--- a/main.py
+++ b/main.py
@@ -176,14 +176,14 @@ def backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,
     # 2. 运行命令自动适配
     if platform.system() == 'Windows':
         if runPath in runCommand:
-            command = f'cd Copy\\{projName} && {pythonPath} {runCommand}'
+            command = f'cd "Copy\\{projName}" && "{pythonPath}" {runCommand}'
         else:
-            command = f'cd Copy\\{projName}\\{runPath} && {pythonPath} {runCommand}'
+            command = f'cd "Copy\\{projName}\\{runPath}" && "{pythonPath}" {runCommand}'
     else:
         if runPath in runCommand:
-            command = f'cd Copy/{projName};{pythonPath} {runCommand}'
+            command = f'cd "Copy/{projName}";"{pythonPath}" {runCommand}'
         else:
-            command = f'cd Copy/{projName}/{runPath};{pythonPath} {runCommand}'
+            command = f'cd "Copy/{projName}/{runPath}";"{pythonPath}" {runCommand}'
     print('Running the project...')
     # createResult=subprocess.run(command,shell=True,executable='/bin/bash',stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True)
     createResult = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)


### PR DESCRIPTION
## Summary
- improve Python executable resolution across environments
- fix Windows path and runPath handling in preprocess and runtime commands
- repair garbled comments in map.py and escape-sequence handling in changeAnalyze.py
- reset per-project fixed logs before each new run to avoid appending across runs

## Included commits
- e4fc73b6ec Fix Python 3 executable resolution across environments
- 2a50a85346 Fix changeAnalyze escape warnings
- 9d9f5b4317 Fix quoted shell paths
- b9873ebb9f Fix garbled comments in map.py
- 90c71f5c30 Fix runPath separator handling
- 7313359f21 Fix preprocess runPath segment counting
- 35f1bc00bf Fix reset fixed log for each project run

## Validation
- python -m pytest tests\\test_changeAnalyze.py -p no:cacheprovider