### PR TITLE
Fix dollar expansion in dynamic match

### DIFF
--- a/Map/map.py
+++ b/Map/map.py
@@ -98,6 +98,8 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
     pklFile=getFileName(callAPI,'.pkl')
     pklStr=pklFile.replace('"','\\"')
     callStr=callAPI.replace('"','\\"')
+    if platform.system() != "Windows":  # 2026/4/24 Avoid shell expansion for $ in callAPI on Unix.
+        callStr = callStr.replace('$', '\\$')
     pklPrefix='../..'
     jsonPrefix='../..'
     


### PR DESCRIPTION
## Summary
- Fix `$` character expansion issue in fuzzy match during dynamic API mapping

## Changes
- `Map/map.py`: Escape dollar signs in replacement strings to prevent unintended variable expansion