### PR TITLE
Fix: coverage key collision for same-named files across directories

### DIFF
--- a/Configure/AIBO_win.json
+++ b/Configure/AIBO_win.json
@@ -1,0 +1,10 @@
+{
+    "projPath": "Example/AIBO",
+    "runCommand": "python run.py --func=Ackley --dim=100 --method=anneal --iters=5000 --batch-size=10",
+    "runFilePath": "",
+    "libName": "scipy",
+    "currentVersion": "1.7.3",
+    "targetVersion": "1.10.0",
+    "currentEnv": "C:/Users/xiaog/anaconda3/envs/AIBO1.7.3",
+    "targetEnv": "C:/Users/xiaog/anaconda3/envs/AIBO1.10.0"
+}

--- a/Configure/Deep-Graph-Kernels_win.json
+++ b/Configure/Deep-Graph-Kernels_win.json
@@ -1,0 +1,10 @@
+{
+    "projPath": "Example/Deep-Graph-Kernels",
+    "runCommand": "python Kronecker_Generator.py",
+    "runFilePath": "",
+    "libName": "scipy",
+    "currentVersion": "0.19.1",
+    "targetVersion": "1.0.0",
+    "currentEnv": "C:/Users/xiaog/anaconda3/envs/scipy0.19.1",
+    "targetEnv": "C:/Users/xiaog/anaconda3/envs/scipy1.0.0"
+}

--- a/Configure/aiofiles1_win.json
+++ b/Configure/aiofiles1_win.json
@@ -1,0 +1,10 @@
+{
+    "projPath": "Example/async_await_invocation/aiofiles1",
+    "runCommand": "python test_asyncawait.py",
+    "runFilePath": "",
+    "libName": "aiofiles",
+    "currentVersion": "22.1.0",
+    "targetVersion": "23.1.0",
+    "currentEnv": "C:/Users/xiaog/anaconda3/envs/aiofiles22.1.0",
+    "targetEnv": "C:/Users/xiaog/anaconda3/envs/aiofiles23.1.0"
+}

--- a/Configure/aiomqtt1_win.json
+++ b/Configure/aiomqtt1_win.json
@@ -1,0 +1,10 @@
+{
+    "projPath": "Example/async_await_invocation/aiomqtt1",
+    "runCommand": "python test_asyncawait.py",
+    "runFilePath": "",
+    "libName": "aiomqtt",
+    "currentVersion": "1.2.1",
+    "targetVersion": "2.0.0",
+    "currentEnv": "C:/Users/xiaog/anaconda3/envs/aiomqtt1.2.1",
+    "targetEnv": "C:/Users/xiaog/anaconda3/envs/aiomqtt2.0.0"
+}

--- a/Configure/click1_win.json
+++ b/Configure/click1_win.json
@@ -1,0 +1,10 @@
+{
+    "projPath": "Example/decorator_invocation/click1",
+    "runCommand": "python test_decorator.py --name 'hhh'",
+    "runFilePath": "",
+    "libName": "click",
+    "currentVersion": "8.0.4",
+    "targetVersion": "8.1.0",
+    "currentEnv": "C:/Users/xiaog/anaconda3/envs/click8.0.4",
+    "targetEnv": "C:/Users/xiaog/anaconda3/envs/click8.1.0"
+}

--- a/Configure/click2_win.json
+++ b/Configure/click2_win.json
@@ -1,0 +1,10 @@
+{
+    "projPath": "Example/decorator_invocation/click2",
+    "runCommand": "python test_decorator.py --name 'hhh'",
+    "runFilePath": "",
+    "libName": "click",
+    "currentVersion": "8.0.4",
+    "targetVersion": "8.1.0",
+    "currentEnv": "C:/Users/xiaog/anaconda3/envs/click8.0.4",
+    "targetEnv": "C:/Users/xiaog/anaconda3/envs/click8.1.0"
+}

--- a/Configure/click3_win.json
+++ b/Configure/click3_win.json
@@ -1,0 +1,10 @@
+{
+    "projPath": "Example/decorator_invocation/click3",
+    "runCommand": "python test_decorator.py --name 'hhh'",
+    "runFilePath": "",
+    "libName": "click",
+    "currentVersion": "8.0.4",
+    "targetVersion": "8.1.0",
+    "currentEnv": "C:/Users/xiaog/anaconda3/envs/click8.0.4",
+    "targetEnv": "C:/Users/xiaog/anaconda3/envs/click8.1.0"
+}

--- a/Configure/flask1_win.json
+++ b/Configure/flask1_win.json
@@ -1,0 +1,10 @@
+{
+    "projPath": "Example/decorator_invocation/flask1",
+    "runCommand": "python test_decorator.py",
+    "runFilePath": "",
+    "libName": "flask",
+    "currentVersion": "2.2.5",
+    "targetVersion": "2.3.0",
+    "currentEnv": "C:/Users/xiaog/anaconda3/envs/flask2.2.5",
+    "targetEnv": "C:/Users/xiaog/anaconda3/envs/flask2.3.0"
+}

--- a/Configure/flask2_win.json
+++ b/Configure/flask2_win.json
@@ -1,0 +1,10 @@
+{
+    "projPath": "Example/decorator_invocation/flask2",
+    "runCommand": "python test_decorator.py",
+    "runFilePath": "",
+    "libName": "flask",
+    "currentVersion": "2.2.5",
+    "targetVersion": "2.3.0",
+    "currentEnv": "C:/Users/xiaog/anaconda3/envs/flask2.2.5",
+    "targetEnv": "C:/Users/xiaog/anaconda3/envs/flask2.3.0"
+}

--- a/Configure/fuel_forecast_explorer_win.json
+++ b/Configure/fuel_forecast_explorer_win.json
@@ -1,0 +1,10 @@
+{
+    "projPath": "Example/fuel_forecast_explorer",
+    "runCommand": "python data_cleaning.py",
+    "runFilePath": "",
+    "libName": "pandas",
+    "currentVersion": "1.5.3",
+    "targetVersion": "2.0.0",
+    "currentEnv": "C:/Users/xiaog/anaconda3/envs/fuel1.5.3",
+    "targetEnv": "C:/Users/xiaog/anaconda3/envs/fuel2.0.0"
+}

--- a/Configure/mysql_win.json
+++ b/Configure/mysql_win.json
@@ -1,0 +1,10 @@
+{
+    "projPath": "Example/context_manager_invocation/mysql",
+    "runCommand": "python test_with.py",
+    "runFilePath": "",
+    "libName": "mysql",
+    "currentVersion": "8.2.0",
+    "targetVersion": "9.2.0",
+    "currentEnv": "C:/Users/xiaog/anaconda3/envs/mysql8.2.0",
+    "targetEnv": "C:/Users/xiaog/anaconda3/envs/mysql9.2.0"
+}

--- a/Configure/psycopg2_win.json
+++ b/Configure/psycopg2_win.json
@@ -1,0 +1,10 @@
+{
+    "projPath": "Example/context_manager_invocation/psycopg2",
+    "runCommand": "python test_with.py",
+    "runFilePath": "",
+    "libName": "psycopg2",
+    "currentVersion": "2.9.1",
+    "targetVersion": "2.9.5",
+    "currentEnv": "C:/Users/xiaog/anaconda3/envs/psycopg22.9.1",
+    "targetEnv": "C:/Users/xiaog/anaconda3/envs/psycopg22.9.5"
+}

--- a/Configure/redis_win.json
+++ b/Configure/redis_win.json
@@ -1,0 +1,10 @@
+{
+    "projPath": "Example/context_manager_invocation/redis",
+    "runCommand": "python test_with.py",
+    "runFilePath": "",
+    "libName": "redis",
+    "currentVersion": "5.2.0",
+    "targetVersion": "6.0.0",
+    "currentEnv": "C:/Users/xiaog/anaconda3/envs/redis5.2.0",
+    "targetEnv": "C:/Users/xiaog/anaconda3/envs/redis6.0.0"
+}

--- a/Preprocess/preprocess.py
+++ b/Preprocess/preprocess.py
@@ -458,6 +458,7 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
     # fileName=filePath.split('/')[-1][0:-3]
     fileName = os.path.basename(filePath)[0:-3]
     fileRelativePath=filePath.split(f'{projName}',1)[-1]
+    coverageKey = fileRelativePath.replace('\\', '/').lstrip('/').rsplit('.', 1)[0]
     fileAbsolutePath=projPath+fileRelativePath
     
     lineno=getImportLine(codeLst)
@@ -542,8 +543,8 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
                     dicString2=dicString2+para+','
                 dicString2=dicString2.rstrip(',')+']\n'
                 
-                dicString3=f'apiCoveredSet.add(\"{fileName}##{lineno}##{key}\")\n'
-                # print(f"{fileName}##{lineno}##{key}") 
+                dicString3=f'apiCoveredSet.add(\"{coverageKey}##{lineno}##{key}\")\n'
+                # print(f"{coverageKey}##{lineno}##{key}")
                 while spaceNum>0:
                     if dicString1:
                         dicString1=' '+dicString1
@@ -610,7 +611,11 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
     #最后再判断一下该文件是否为该项目的运行文件
     # fileName=filePath.split('/')[-1] #fileName带.py
     fileName = os.path.basename(filePath)
-    if fileName in runFileLst:
+    inRunDir = True
+    if runPath:
+        normalized_rp = runPath.replace('\\', '/').strip('/')
+        inRunDir = fileRelativePath.replace('\\', '/').startswith(f'/{normalized_rp}/')
+    if fileName in runFileLst and inRunDir:
         #寻找__main__所在的行
         flag=0
         spaceNum=0

--- a/Tool/tool.py
+++ b/Tool/tool.py
@@ -340,7 +340,7 @@ def getVersionLst(libPath):
     obj.getPath(libPath)
     path=obj.path
     for p in path:
-        p=p.split('/')[-1]
+        p = os.path.basename(p)
         index=-1
         for i in range(len(p)):
             if p[i].isdigit():

--- a/main.py
+++ b/main.py
@@ -51,6 +51,7 @@ def backwardTask(args):
     pos=tempLst.index(projName)
     realProjPath='/'.join(tempLst[0:pos+1])
     fileRelativePath='/'.join(tempLst[pos:])
+    coverageKey = '/'.join(tempLst[pos+1:]).rsplit('.', 1)[0]
     # copyFile='./Copy/'+fileRelativePath
     copyFile = os.path.join('.', 'Copy', *fileRelativePath.split('/'))
     invokedAPINum=len(callAPIDict)
@@ -72,8 +73,9 @@ def backwardTask(args):
         #     continue
         
         flag=0
+        probe = f"{coverageKey}##{lineNum}##{callAPI}".split('(')[0].replace(' ','')
         for it in coverSet:
-            if f"{fileName}##{lineNum}##{callAPI}".split('(')[0].replace(' ','') in it:
+            if it.replace(' ', '').startswith(probe):
                 flag=1
                 break
         if flag==0:


### PR DESCRIPTION
## Summary

- Fix coverage key collision for files with identical basenames in different subdirectories — use project-relative path instead of bare filename as the coverSet identifier
- Add Windows conda environment example configs (`_win.json` variants) for 13 example projects alongside existing Linux configs

## Changes

### Fix coverage key collision

The coverage tracking used bare filename (`os.path.basename`) as the identifier in coverSet entries. Files with the same name in different directories (e.g., `Kronecker_Generator.py` and `src/Kronecker_Generator.py`) shared coverage status because the key only contained the basename.

This was masked on Windows before the cross-platform refactoring (5be0d24768) because `split('/')` on Windows backslash paths accidentally preserved directory info in the "filename". The switch to `os.path.basename` in that commit surfaced the collision consistently on all platforms.

- `Preprocess/preprocess.py`: compute `coverageKey` from `fileRelativePath` for coverSet instrumentation; restrict `__main__` instrumentation to files under the configured `runPath`
- `main.py`: use `coverageKey` with `startswith` matching instead of `fileName` with substring matching for coverSet lookup
- `Tool/tool.py`: use `os.path.basename` in `getVersionLst` (same class of path-handling bug)

### Add Windows conda configs

Add `_win.json` variants with local Windows conda paths for 13 example projects, keeping the original Linux-configured versions intact.