### PR TITLE
Fix receiver candidate dynamic matching fallbacks

### DIFF
--- a/Change/changeAnalyze.py
+++ b/Change/changeAnalyze.py
@@ -627,15 +627,26 @@ def isCompatible(current,target):
 #  @parami errLst Error message logging list
 #  @return lst[0] The API call string with added parameter values (load from pkl file) 
 # def addValueForAPI(callAPI,projName,runPath,runCommand,virtualEnv,errLst):
-def addValueForAPI(callAPI,projName,runPath,runCommand,currentEnv,targetEnv,errLst):
-    pklName=getFileName(callAPI,'.pkl')
+def addValueForAPI(callAPI,projName,runPath,runCommand,currentEnv,targetEnv,errLst,callKey=None):
+    pklKey = callKey or callAPI
+    pklName=getFileName(pklKey,'.pkl')
     flag=0
-    if os.path.exists(f"Copy/pkl/new_{pklName}"):
-        flag=1
-        pklPath=f"../../Copy/pkl/new_{pklName}"
-    elif os.path.exists(f"Copy/pkl/{pklName}"):
-        pklPath=f"../../Copy/pkl/{pklName}"
-    else:
+    # 参数补值沿用动态匹配的候选顺序，并优先使用目标环境重新生成的pkl
+    pklCandidates=[
+        ('new_'+pklName[:-4]+'__object.pkl',1),
+        ('new_'+pklName[:-4]+'__expr.pkl',1),
+        ('new_'+pklName,1),
+        (pklName[:-4]+'__object.pkl',0),
+        (pklName[:-4]+'__expr.pkl',0),
+        (pklName,0),
+    ]
+    pklPath=''
+    for candidateName,candidateFlag in pklCandidates:
+        if os.path.exists(f"Copy/pkl/{candidateName}"):
+            flag=candidateFlag
+            pklPath=f"../../Copy/pkl/{candidateName}"
+            break
+    if not pklPath:
         return ''
     
     # pklPath=f"../../Copy/pkl/{pklName}"
@@ -672,7 +683,7 @@ def addValueForAPI(callAPI,projName,runPath,runCommand,currentEnv,targetEnv,errL
         cwd = os.path.join('Dynamic', projName)
         script = 'addValueForAPI.py'
     matchResult = subprocess.run(
-        [pythonPath, script, pklPath, callAPI],
+        [pythonPath, script, pklPath, callAPI, pklKey],
         cwd=cwd, capture_output=True, text=True, encoding='utf-8'
     )
     # print(command)

--- a/Extract/extractCall.py
+++ b/Extract/extractCall.py
@@ -85,14 +85,40 @@ class GetFuncCall:
 #  对于withitem节点，提取其中的call节点和别名（如果有）
 class WithVisitor(ast.NodeVisitor):
     def __init__(self):
+        # 同名with别名可能在不同作用域重复出现，因此按别名保存所有候选及其行号范围
         self._withitemCall={}
     
     def get_withitem_call(self):
         return self._withitemCall
 
+    def visit_With(self, node):
+        # 手动遍历body，避免generic_visit再次访问withitem导致重复记录
+        self._visit_with_items(node)
+        for stmt in node.body:
+            self.visit(stmt)
+
+    def visit_AsyncWith(self, node):
+        # AsyncWith和With保持相同的withitem别名还原规则
+        self._visit_with_items(node)
+        for stmt in node.body:
+            self.visit(stmt)
+
+    def _visit_with_items(self, node):
+        for item in node.items:
+            self._record_withitem(item, node)
+
     def visit_withitem(self, node):
+        self._record_withitem(node)
+
+    def _record_withitem(self, node, parent=None):
         if isinstance(node.context_expr, ast.Call):
             if node.optional_vars:
                 callName =  ast.unparse(node.context_expr)
                 aliasName = ast.unparse(node.optional_vars)
-                self._withitemCall[aliasName] = callName
+                # lineno/end_lineno用于后续按调用点选择当前作用域内的withitem
+                item = {
+                    'callName': callName,
+                    'lineno': getattr(parent, 'lineno', None),
+                    'end_lineno': getattr(parent, 'end_lineno', None),
+                }
+                self._withitemCall.setdefault(aliasName, []).append(item)

--- a/Extract/getCall.py
+++ b/Extract/getCall.py
@@ -149,17 +149,36 @@ def modifyFirstName(prefix, callName, paraStr, codeLst):
 #  @param callName API call item in source code
 #  @param withitemCallName A dict stores the alias and its counterpart withitem call name
 #  @return The conventional API call path
-def modifyWithName(callName, withitemCallName):
+def modifyWithName(callName, withitemCallName, lineno=None):
     name_parts = callName.split('.') #按.进行字段拆分
     firstModify = callName
     modifyFlag = 0
     if name_parts[0] in withitemCallName:
-        firstModify = withitemCallName[name_parts[0]] + '.' + '.'.join(name_parts[1:])
-        modifyFlag = 1
+        withitem = withitemCallName[name_parts[0]]
+        if isinstance(withitem, list):
+            candidates = withitem
+            if lineno is not None:
+                # with别名同名时，只使用覆盖当前调用行号的候选，避免外层/兄弟作用域误还原
+                scoped = []
+                for item in candidates:
+                    start = item.get('lineno')
+                    end = item.get('end_lineno')
+                    if start is not None and end is not None and start <= lineno <= end:
+                        scoped.append(item)
+                candidates = scoped
+            if candidates:
+                # 嵌套with中内层别名优先；行号越靠后的候选作用域越内层
+                candidates = sorted(candidates, key=lambda item: item.get('lineno') or -1)
+                withitem = candidates[-1].get('callName')
+            else:
+                withitem = None
+        if withitem:
+            firstModify = withitem + '.' + '.'.join(name_parts[1:])
+            modifyFlag = 1
 
     #找到了withitem call，重新试探一下前面是否还有withitem call语句
     if modifyFlag:
-        return modifyWithName(firstModify, withitemCallName)
+        return modifyWithName(firstModify, withitemCallName, lineno)
     #若没有，则直接结束 
     else:
         return callName 
@@ -255,7 +274,7 @@ def getCallFunction(filePath,libName):
 
             # #再将withitem call的别名还原为真名（如有）-- 2025/5/19
             if len(withitem_call_names) !=0:
-                firstModify = modifyWithName(callName, withitem_call_names)
+                firstModify = modifyWithName(callName, withitem_call_names, lineno)
                 secondModify = firstModify
 
             # #最后将import的别名还原成真名

--- a/Map/map.py
+++ b/Map/map.py
@@ -108,6 +108,28 @@ def saveDynamicMatchSnapshot(pklKey,version,curr,dynamicMatchDict,pklFile=None):
         json.dump(snapshotDict,fw,indent=4,ensure_ascii=False)
 
 
+## Check whether a callsite candidate manifest records pkl save failure
+## 检查调用点候选清单是否记录了pkl保存失败
+#
+#  @param pklKey The callsite key used to locate the manifest
+#  @return result Whether any candidate was covered but failed to save
+def hasSaveFailedManifest(pklKey):
+    manifestPath=f"Copy/pkl/{getFileName(pklKey,'.manifest.json')}"
+    if not os.path.exists(manifestPath):
+        return False
+    try:
+        with open(manifestPath,'r',encoding='UTF-8') as fr:
+            manifest=json.load(fr)
+    except Exception:
+        return False
+    if not manifest.get('covered'):
+        return False
+    for candidate in manifest.get('candidates',[]):
+        if candidate.get('status')=='save_failed':
+            return True
+    return False
+
+
 
 ## Dynamic mapping of API signatures
 ## API签名动态匹配 
@@ -143,10 +165,6 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
             jsonPrefix='../'+jsonPrefix
             l-=1
 
-    existingPklFiles=[file for file in pklCandidateFiles if os.path.exists(f"Copy/pkl/{file}")]
-    if not existingPklFiles:
-        return False
-
     # if runPath!='':
     #     if runPath not in runCommand:
     #         command=f'cd "Dynamic/{projName}/{runPath}";"{pythonPath}" dynamicMatch.py "{pklPrefix}/Copy/pkl/{pklStr}" "{callStr}" "{jsonPrefix}"'
@@ -162,28 +180,34 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
         dynamic_script = os.path.join(runPath, 'dynamicMatch.py') if runPath else 'dynamicMatch.py'
     lastResult = None
     lastDynamicMatchDict = None
-    for candidatePklFile in existingPklFiles:
-        # 某个候选返回nullptr时继续尝试下一个候选，避免可inspect调用被提前判为static
-        pkl_arg = os.path.join(pklPrefix, 'Copy', 'pkl', candidatePklFile)
-        matchResult = subprocess.run(
-            [pythonPath, dynamic_script, pkl_arg, callAPI, jsonPrefix, pklKey],
-            cwd=dynamic_cwd, capture_output=True, text=True, encoding='utf-8'
-        )
-        lastResult = matchResult
-        if matchResult.returncode == 0:
-            fileName=getFileName(pklKey,'_dynamicMatch.json')
-            with open(f"data/{fileName}",'r',encoding='UTF-8') as fr:
-                try:
-                    dynamicMatchDict=json.load(fr)
-                except Exception as e:
-                    dynamicMatchDict=None
-                    print(f"json load data/{fileName} failed: {e}\n")
-            lastDynamicMatchDict = dynamicMatchDict
-            if dynamicMatchDict and dynamicMatchDict.get('match') != 'nullptr':
-                saveDynamicMatchSnapshot(pklKey,version,curr,dynamicMatchDict,candidatePklFile)
-                return dynamicMatchDict
+    existingPklFiles=[file for file in pklCandidateFiles if os.path.exists(f"Copy/pkl/{file}")]
+    if not existingPklFiles:
+        if curr or not hasSaveFailedManifest(pklKey):
+            return False
+        lastResult=subprocess.CompletedProcess([],1,'','manifest save_failed')
+    else:
+        for candidatePklFile in existingPklFiles:
+            # 某个候选返回nullptr时继续尝试下一个候选，避免可inspect调用被提前判为static
+            pkl_arg = os.path.join(pklPrefix, 'Copy', 'pkl', candidatePklFile)
+            matchResult = subprocess.run(
+                [pythonPath, dynamic_script, pkl_arg, callAPI, jsonPrefix, pklKey],
+                cwd=dynamic_cwd, capture_output=True, text=True, encoding='utf-8'
+            )
+            lastResult = matchResult
+            if matchResult.returncode == 0:
+                fileName=getFileName(pklKey,'_dynamicMatch.json')
+                with open(f"data/{fileName}",'r',encoding='UTF-8') as fr:
+                    try:
+                        dynamicMatchDict=json.load(fr)
+                    except Exception as e:
+                        dynamicMatchDict=None
+                        print(f"json load data/{fileName} failed: {e}\n")
+                lastDynamicMatchDict = dynamicMatchDict
+                if dynamicMatchDict and dynamicMatchDict.get('match') != 'nullptr':
+                    saveDynamicMatchSnapshot(pklKey,version,curr,dynamicMatchDict,candidatePklFile)
+                    return dynamicMatchDict
+                continue
             continue
-        continue
 
     if lastResult is None:
         return False

--- a/Map/map.py
+++ b/Map/map.py
@@ -77,6 +77,37 @@ def fuzzymatch(formatAPI,libName,version,builtinFlag): #callAPIDict是传入传�
     return ansDict 
 
 
+## Save dynamic match result snapshot
+## 保存动态匹配结果快照
+#
+#  @param pklKey The callsite key used to locate the pkl/json data
+#  @param version The lib version used in this dynamic match
+#  @param curr Current version flag, 1 for current and 0 for target
+#  @param dynamicMatchDict Dynamic match result loaded from dynamicMatch.py
+#  @param pklFile The pkl candidate file used by this dynamic match
+#
+def saveDynamicMatchSnapshot(pklKey,version,curr,dynamicMatchDict,pklFile=None):
+    if not isinstance(dynamicMatchDict,dict):
+        return
+    phase='current' if curr else 'target'
+    # getFileName(...,'.json')会处理Windows非法文件名字符，再去掉扩展名用于拼接快照文件名
+    safeKey=getFileName(pklKey,'.json')[:-5]
+    safeVersion=str(version).replace(os.sep,'_').replace('/','_').replace('\\','_')
+    snapshotDict=dict(dynamicMatchDict)
+    # 保留current/target最终动态匹配结果，原dynamicMatch.json仍作为子进程通信文件
+    snapshotDict['_pcart']={
+        'phase': phase,
+        'version': str(version),
+        'callKey': pklKey,
+    }
+    if pklFile is not None:
+        snapshotDict['_pcart']['pklFile']=pklFile
+    os.makedirs('data',exist_ok=True)
+    fileName=f"{phase}_{safeKey}_{safeVersion}_dynamicMatch.json"
+    with open(f"data/{fileName}",'w',encoding='UTF-8') as fw:
+        json.dump(snapshotDict,fw,indent=4,ensure_ascii=False)
+
+
 
 ## Dynamic mapping of API signatures
 ## API签名动态匹配 
@@ -92,10 +123,13 @@ def fuzzymatch(formatAPI,libName,version,builtinFlag): #callAPIDict是传入传�
 #  @param errLst Error list
 #  @param curr=1 Current version flag
 #  @return dynamicMatchDict Mapped API signatures 
-def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv,lock,errLst,curr=1):
+def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv,lock,errLst,curr=1,callKey=None):
     # pythonPath=f"{virtualEnv}/bin/python" #先指定python解释器的路径
     pythonPath = resolvePythonExecutable(virtualEnv)
-    pklFile=getFileName(callAPI,'.pkl')
+    pklKey = callKey or callAPI
+    pklFile=getFileName(pklKey,'.pkl')
+    # withitem调用优先尝试运行时对象，其次尝试还原表达式，最后兼容旧版单pkl
+    pklCandidateFiles=[pklFile[:-4]+'__object.pkl',pklFile[:-4]+'__expr.pkl',pklFile]
     pklPrefix='../..'
     jsonPrefix='../..'
 
@@ -109,7 +143,8 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
             jsonPrefix='../'+jsonPrefix
             l-=1
 
-    if not os.path.exists(f"Copy/pkl/{pklFile}"):
+    existingPklFiles=[file for file in pklCandidateFiles if os.path.exists(f"Copy/pkl/{file}")]
+    if not existingPklFiles:
         return False
 
     # if runPath!='':
@@ -125,13 +160,37 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
     else:
         dynamic_cwd = os.path.join('Dynamic', projName)
         dynamic_script = os.path.join(runPath, 'dynamicMatch.py') if runPath else 'dynamicMatch.py'
-    pkl_arg = os.path.join(pklPrefix, 'Copy', 'pkl', pklFile)
-    matchResult = subprocess.run(
-        [pythonPath, dynamic_script, pkl_arg, callAPI, jsonPrefix],
-        cwd=dynamic_cwd, capture_output=True, text=True, encoding='utf-8'
-    )
-    stdout = matchResult.stdout
-    stderr = matchResult.stderr
+    lastResult = None
+    lastDynamicMatchDict = None
+    for candidatePklFile in existingPklFiles:
+        # 某个候选返回nullptr时继续尝试下一个候选，避免可inspect调用被提前判为static
+        pkl_arg = os.path.join(pklPrefix, 'Copy', 'pkl', candidatePklFile)
+        matchResult = subprocess.run(
+            [pythonPath, dynamic_script, pkl_arg, callAPI, jsonPrefix, pklKey],
+            cwd=dynamic_cwd, capture_output=True, text=True, encoding='utf-8'
+        )
+        lastResult = matchResult
+        if matchResult.returncode == 0:
+            fileName=getFileName(pklKey,'_dynamicMatch.json')
+            with open(f"data/{fileName}",'r',encoding='UTF-8') as fr:
+                try:
+                    dynamicMatchDict=json.load(fr)
+                except Exception as e:
+                    dynamicMatchDict=None
+                    print(f"json load data/{fileName} failed: {e}\n")
+            lastDynamicMatchDict = dynamicMatchDict
+            if dynamicMatchDict and dynamicMatchDict.get('match') != 'nullptr':
+                saveDynamicMatchSnapshot(pklKey,version,curr,dynamicMatchDict,candidatePklFile)
+                return dynamicMatchDict
+            continue
+        continue
+
+    if lastResult is None:
+        return False
+
+    stdout = lastResult.stdout
+    stderr = lastResult.stderr
+    matchResult = lastResult
 
     # print(f"{callAPI}{version}")
     # print(matchResult.stdout,matchResult.stderr)
@@ -150,8 +209,8 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
             loadError=f"{callAPI}, Failed to load pkl in target version{version}: {matchResult.stderr}\n" 
             with lock:
                 shutil.copy2(copyFile,f"{copyFile}.bak")
-                addDictSingle(callAPI,copyFile) #添加字典并运行，在当前文件中添加字典，在运行文件中
-                pklFile='new_'+pklFile #更新pkl文件名
+                addDictSingle(callAPI,copyFile,pklKey) #添加字典并运行，在当前文件中添加字典，在运行文件中
+                regeneratedPklFiles=[]
                 if runPath and runPath not in runCommand:
                     copy_cwd = os.path.join('Copy', projName, runPath)
                 else:
@@ -162,11 +221,19 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
                     cwd=copy_cwd, capture_output=True, text=True, encoding='utf-8'
                 )
                 if generateResult.returncode==0:
-                    shutil.move(
-                        os.path.join('Copy', 'pkl', 'paraValue.pkl'),
-                        os.path.join('Copy', 'pkl', pklFile)
-                    )
-            
+                    # target环境重生成时保留object/expr候选顺序，避免退回混合老格式pkl
+                    regeneratedCandidates=[
+                        ('paraValue__object.pkl','new_'+pklFile[:-4]+'__object.pkl'),
+                        ('paraValue__expr.pkl','new_'+pklFile[:-4]+'__expr.pkl'),
+                        ('paraValue.pkl','new_'+pklFile),
+                    ]
+                    for sourceName,targetName in regeneratedCandidates:
+                        sourcePath=os.path.join('Copy','pkl',sourceName)
+                        if os.path.exists(sourcePath):
+                            targetPath=os.path.join('Copy','pkl',targetName)
+                            os.replace(sourcePath,targetPath)
+                            regeneratedPklFiles.append(targetName)
+             
                 #插桩完后，再将备份后的文件进行还原
                 os.remove(copyFile)
                 shutil.move(f'{copyFile}.bak',copyFile)
@@ -176,34 +243,41 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
                 errLst.append(f'[{version}]{callAPI}, generate new pkl failed: {generateResult.stderr}\n')
                 return False
             else:
-                pkl_arg = os.path.join(pklPrefix, 'Copy', 'pkl', pklFile)
-                matchResult = subprocess.run(
-                    [pythonPath, dynamic_script, pkl_arg, callAPI, jsonPrefix],
-                    cwd=dynamic_cwd, capture_output=True, text=True, encoding='utf-8'
-                )
-                if matchResult.returncode!=0:
-                    errLst.append(f"[{version}]{callAPI}, load new pkl failed: {matchResult.stderr}\n") 
+                if not regeneratedPklFiles:
+                    errLst.append(f'[{version}]{callAPI}, generate new pkl failed: no pkl file generated\n')
                     return False
-                else:
-                    fileName=getFileName(callAPI,'_dynamicMatch.json')
+                for regeneratedPklFile in regeneratedPklFiles:
+                    pkl_arg = os.path.join(pklPrefix, 'Copy', 'pkl', regeneratedPklFile)
+                    matchResult = subprocess.run(
+                        [pythonPath, dynamic_script, pkl_arg, callAPI, jsonPrefix, pklKey],
+                        cwd=dynamic_cwd, capture_output=True, text=True, encoding='utf-8'
+                    )
+                    if matchResult.returncode!=0:
+                        continue
+                    fileName=getFileName(pklKey,'_dynamicMatch.json')
                     with open(f"data/{fileName}",'r',encoding='UTF-8') as fr:
                         try:
                             dynamicMatchDict=json.load(fr)
                         except Exception as e:
+                            dynamicMatchDict=None
                             print(f"json load data/{fileName} failed: {e}\n")
-                    return dynamicMatchDict
+                    if dynamicMatchDict and dynamicMatchDict.get('match') != 'nullptr':
+                        saveDynamicMatchSnapshot(pklKey,version,curr,dynamicMatchDict,regeneratedPklFile)
+                        return dynamicMatchDict
+                    lastDynamicMatchDict=dynamicMatchDict
+                if lastDynamicMatchDict:
+                    saveDynamicMatchSnapshot(pklKey,version,curr,lastDynamicMatchDict)
+                    return lastDynamicMatchDict
+                errLst.append(f"[{version}]{callAPI}, load new pkl failed: {matchResult.stderr}\n") 
+                return False
 
         else:
             return False    
 
     else:
-        fileName=getFileName(callAPI,'_dynamicMatch.json')
-        with open(f"data/{fileName}",'r',encoding='UTF-8') as fr:
-            try:
-                dynamicMatchDict=json.load(fr)
-            except Exception as e:
-                print(f"json load data/{fileName} failed: {e}\n")
-        return dynamicMatchDict
+        if lastDynamicMatchDict:
+            saveDynamicMatchSnapshot(pklKey,version,curr,lastDynamicMatchDict)
+        return lastDynamicMatchDict
 
 
 
@@ -225,8 +299,8 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
 #  @param errLst Error list
 #  @param curr=1 Current version flag
 #  @return ans Mapped API signatures 
-def mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,version,virtualEnv,lock,errLst,curr=1):
-    dynamicMatchDict=dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv,lock,errLst,curr)
+def mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,version,virtualEnv,lock,errLst,curr=1,callKey=None):
+    dynamicMatchDict=dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv,lock,errLst,curr,callKey)
     ans={}
     ans['format']=formatAPI
     if dynamicMatchDict!=False: #若动态匹配成功,还要对动态匹配的结果进行检查

--- a/Preprocess/preprocess.py
+++ b/Preprocess/preprocess.py
@@ -262,6 +262,76 @@ def findAssignCall(root):
             assignLst.append(target)
     return assignLst
 
+
+## Resolve the source expression assigned to a receiver alias
+## 还原调用者别名在当前作用域内的赋值来源表达式
+#
+#  @param root The AST root of the source code
+#  @param source The original source code
+#  @param aliasName The first name of the receiver alias
+#  @param lineno The line number of the call site
+#  @return expr The scoped assignment expression or None
+def getAssignReceiverExpr(root,source,aliasName,lineno):
+    expr=None
+    bestLine=-1
+
+    scopeBodies=[root.body]
+    for node in ast.walk(root):
+        if isinstance(node,(ast.FunctionDef,ast.AsyncFunctionDef,ast.ClassDef)):
+            start=node.lineno
+            end=getattr(node,'end_lineno',start)
+            if start<lineno<=end:
+                scopeBodies.append(node.body)
+
+    for body in scopeBodies:
+        for stmt in body:
+            if not hasattr(stmt,'lineno') or stmt.lineno>=lineno:
+                continue
+            if isinstance(stmt,(ast.If,ast.For,ast.AsyncFor,ast.While,ast.Try,ast.With,ast.AsyncWith)):
+                continue
+            value=None
+            targets=[]
+            if isinstance(stmt,ast.Assign):
+                value=stmt.value
+                targets=stmt.targets
+            elif isinstance(stmt,ast.AnnAssign):
+                value=stmt.value
+                targets=[stmt.target]
+            if value is None:
+                continue
+            for target in targets:
+                if isinstance(target,ast.Name) and target.id==aliasName and stmt.lineno>bestLine:
+                    sourceExpr=ast.get_source_segment(source,value)
+                    if sourceExpr:
+                        expr=sourceExpr.strip()
+                        bestLine=stmt.lineno
+    return expr
+
+
+## Resolve the visible base-class expression for an inherited self receiver
+## 还原继承场景中self调用者可见的基类表达式
+#
+#  @param root The AST root of the source code
+#  @param lineno The line number of the call site
+#  @param methodName The self method name
+#  @return expr The base-class expression or None
+def getSelfReceiverExpr(root,lineno,methodName):
+    for node in ast.walk(root):
+        if not isinstance(node,ast.ClassDef):
+            continue
+        start=node.lineno
+        end=getattr(node,'end_lineno',start)
+        if not (start<lineno<=end) or len(node.bases)==0:
+            continue
+        defNames=set()
+        for item in ast.iter_child_nodes(node):
+            if isinstance(item,(ast.FunctionDef,ast.AsyncFunctionDef)):
+                defNames.add(item.name)
+        if methodName in defNames:
+            return None
+        return ast.unparse(node.bases[0])
+    return None
+
     
 
 ## Count the number of spaces at the beginning of a string 
@@ -336,6 +406,7 @@ def extractDecorator(root):
 def addDictSingle(callAPI,filePath,callKey=None):
     with open(filePath,'r',encoding='UTF-8') as fr:
         codeLst=fr.readlines()
+    source=''.join(codeLst)
     
     lineno=getImportLine(codeLst)
     importDict='from recordValue import paraValueDict\n'
@@ -366,7 +437,18 @@ def addDictSingle(callAPI,filePath,callKey=None):
             
             key=(callKey or callAPI).replace('"','\\"')
             if firstPart and (firstPart.split('.')[0] in targetLst or firstPart.split('.')[0]=='self') and len(l)==1:
-                dicString1=f'paraValueDict[\"@{key}\"]={firstPart}\n'
+                lineNo = i + 1
+                receiverExpr=None
+                if firstPart.split('.')[0] in targetLst:
+                    receiverExpr=getAssignReceiverExpr(root,source,firstPart.split('.')[0],lineNo)
+                elif firstPart.split('.')[0]=='self':
+                    methodName=callAPI.split('(')[0].split('.')[-1]
+                    receiverExpr=getSelfReceiverExpr(root,lineNo,methodName)
+                if receiverExpr:
+                    receiverExpr=receiverExpr.replace('\\','\\\\').replace('"','\\"')
+                    dicString1=f'paraValueDict[\"@{key}\"]={{}}; paraValueDict[\"@{key}\"][\"object\"]={firstPart}; paraValueDict[\"@{key}\"][\"expr\"]=\"{receiverExpr}\"\n'
+                else:
+                    dicString1=f'paraValueDict[\"@{key}\"]={firstPart}\n'
             elif len(l)>1: #df.a(x).b(y), np.max(...), torch.nn.Sequential(...)
                 dicString1=f'paraValueDict[\"@{key}\"]={l[-2]}\n'
 
@@ -374,8 +456,8 @@ def addDictSingle(callAPI,filePath,callKey=None):
             if firstPart and firstPart.split('.')[0] in withitem_call_names:
                 lineNo = i + 1
                 initialCallName = modifyWithName(firstPart, withitem_call_names, lineNo).rstrip('.')
-                initialCallName = initialCallName.replace('"','\\"')
                 # withitem接收者同时保存运行时对象和还原表达式，动态阶段按可用候选依次尝试
+                initialCallName=initialCallName.replace('\\','\\\\').replace('"','\\"')
                 dicString1=f'paraValueDict[\"@{key}\"]={{}}; paraValueDict[\"@{key}\"][\"object\"]={firstPart}; paraValueDict[\"@{key}\"][\"expr\"]=\"{initialCallName}\"\n'
             
             #再保存API的参数值 
@@ -523,7 +605,17 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
                 # if '(' not in firstPart and (firstPart in targetLst or firstPart=='self'):
                 #self.f(x), a.f(x), a.b.c(x)
                 if firstPart and (firstPart.split('.')[0] in targetLst or firstPart.split('.')[0]=='self') and len(l)==1:
-                    dicString1=f'paraValueDict[\"@{callSiteKey}\"]={firstPart}\n'
+                    receiverExpr=None
+                    if firstPart.split('.')[0] in targetLst:
+                        receiverExpr=getAssignReceiverExpr(root,code,firstPart.split('.')[0],lineno)
+                    elif firstPart.split('.')[0]=='self':
+                        methodName=callState.split('(')[0].split('.')[-1]
+                        receiverExpr=getSelfReceiverExpr(root,lineno,methodName)
+                    if receiverExpr:
+                        receiverExpr=receiverExpr.replace('\\','\\\\').replace('"','\\"')
+                        dicString1=f'paraValueDict[\"@{callSiteKey}\"]={{}}; paraValueDict[\"@{callSiteKey}\"][\"object\"]={firstPart}; paraValueDict[\"@{callSiteKey}\"][\"expr\"]=\"{receiverExpr}\"\n'
+                    else:
+                        dicString1=f'paraValueDict[\"@{callSiteKey}\"]={firstPart}\n'
                 elif len(l)>1: #df.a(x).b(y), np.max(...), torch.nn.Sequential(...)
                     dicString1=f'paraValueDict[\"@{callSiteKey}\"]={l[-2]}\n'
                
@@ -531,8 +623,8 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
                 if firstPart and firstPart.split('.')[0] in withitem_call_names:
                     initialCallName = modifyWithName(firstPart, withitem_call_names, lineno).rstrip('.')
                     initialCallName = initialCallName.rstrip('.')
-                    initialCallName = initialCallName.replace('"','\\"')
                     # withitem接收者同时保存运行时对象和还原表达式，非withitem调用仍保持原有单值保存
+                    initialCallName=initialCallName.replace('\\','\\\\').replace('"','\\"')
                     dicString1=f'paraValueDict[\"@{callSiteKey}\"]={{}}; paraValueDict[\"@{callSiteKey}\"][\"object\"]={firstPart}; paraValueDict[\"@{callSiteKey}\"][\"expr\"]=\"{initialCallName}\"\n'
                 #再保存API的参数值
                 dicString2=f'paraValueDict[\"{callSiteKey}\"]=['

--- a/Preprocess/preprocess.py
+++ b/Preprocess/preprocess.py
@@ -333,7 +333,7 @@ def extractDecorator(root):
 #
 #  @param callAPI The API call
 #  @param filePath The source file path
-def addDictSingle(callAPI,filePath):
+def addDictSingle(callAPI,filePath,callKey=None):
     with open(filePath,'r',encoding='UTF-8') as fr:
         codeLst=fr.readlines()
     
@@ -364,7 +364,7 @@ def addDictSingle(callAPI,filePath):
                     firstPart+=it+'.'
             firstPart=firstPart.rstrip('.')
             
-            key=callAPI.replace('"','\\"')
+            key=(callKey or callAPI).replace('"','\\"')
             if firstPart and (firstPart.split('.')[0] in targetLst or firstPart.split('.')[0]=='self') and len(l)==1:
                 dicString1=f'paraValueDict[\"@{key}\"]={firstPart}\n'
             elif len(l)>1: #df.a(x).b(y), np.max(...), torch.nn.Sequential(...)
@@ -372,10 +372,11 @@ def addDictSingle(callAPI,filePath):
 
             #判断API是否为withitem中的别名调用 -- 2025/5/19 
             if firstPart and firstPart.split('.')[0] in withitem_call_names:
-                if len(withitem_call_names) > 1: #2026/4/22 Fix withitem caller instrucmentation
-                    dicString1=f'paraValueDict[\"@{key}\"]=\"{withitem_call_names[firstPart.split(".")[0]]}\"\n'
-                else:
-                    dicString1=f'paraValueDict[\"@{key}\"]={firstPart}\n'
+                lineNo = i + 1
+                initialCallName = modifyWithName(firstPart, withitem_call_names, lineNo).rstrip('.')
+                initialCallName = initialCallName.replace('"','\\"')
+                # withitem接收者同时保存运行时对象和还原表达式，动态阶段按可用候选依次尝试
+                dicString1=f'paraValueDict[\"@{key}\"]={{}}; paraValueDict[\"@{key}\"][\"object\"]={firstPart}; paraValueDict[\"@{key}\"][\"expr\"]=\"{initialCallName}\"\n'
             
             #再保存API的参数值 
             dicString2=f'paraValueDict[\"{key}\"]'+'=['
@@ -469,8 +470,12 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
     targetLst=findAssignCall(root) #用来区分调用者是否来自赋值语句，比如a.f(), tf.f(), or self.f()
  
     #找出树中所有withitem call节点 -- 2025/5/19
+    try:
+        withitem_root = getAst(fileAbsolutePath)
+    except Exception:
+        withitem_root = root
     withitem_visitor = WithVisitor()
-    withitem_visitor.visit(root)
+    withitem_visitor.visit(withitem_root)
     withitem_call_names = withitem_visitor.get_withitem_call() #dict
 
     insertStartLine=0 #记录每次插桩的行
@@ -502,6 +507,7 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
                 #key=callState.replace('"','\\"') #把字符串中的"改成\"
                 key=getFileName(callState,'') # 2025/5/25 Fix inconsistency between callAPI name and the key name 
                 key=key.replace('"','\\"') #把字符串中的"改成\"
+                callSiteKey=f'{key}#_{lineno}'
                 l=departAPI(callState)
                 l2=departAPI2(callState)
                 firstPart=''
@@ -517,21 +523,19 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
                 # if '(' not in firstPart and (firstPart in targetLst or firstPart=='self'):
                 #self.f(x), a.f(x), a.b.c(x)
                 if firstPart and (firstPart.split('.')[0] in targetLst or firstPart.split('.')[0]=='self') and len(l)==1:
-                    dicString1=f'paraValueDict[\"@{key}\"]={firstPart}\n'
+                    dicString1=f'paraValueDict[\"@{callSiteKey}\"]={firstPart}\n'
                 elif len(l)>1: #df.a(x).b(y), np.max(...), torch.nn.Sequential(...)
-                    dicString1=f'paraValueDict[\"@{key}\"]={l[-2]}\n'
+                    dicString1=f'paraValueDict[\"@{callSiteKey}\"]={l[-2]}\n'
                
                 #判断API是否为withitem中的别名调用 -- 2025/5/19 
                 if firstPart and firstPart.split('.')[0] in withitem_call_names:
-                    if len(withitem_call_names) > 1: #2026/4/22 Fix withitem caller instrucmentation
-                        initialCallName = modifyWithName(firstPart, withitem_call_names).rstrip('.')
-                        initialCallName = initialCallName.rstrip('.')
-                        #dicString1=f'paraValueDict[\"@{key}\"]=\"{withitem_call_names[firstPart.split(".")[0]]}\"\n'
-                        dicString1=f'paraValueDict[\"@{key}\"]=\"{initialCallName}\"\n'
-                    else:
-                        dicString1=f'paraValueDict[\"@{key}\"]={firstPart}\n'
+                    initialCallName = modifyWithName(firstPart, withitem_call_names, lineno).rstrip('.')
+                    initialCallName = initialCallName.rstrip('.')
+                    initialCallName = initialCallName.replace('"','\\"')
+                    # withitem接收者同时保存运行时对象和还原表达式，非withitem调用仍保持原有单值保存
+                    dicString1=f'paraValueDict[\"@{callSiteKey}\"]={{}}; paraValueDict[\"@{callSiteKey}\"][\"object\"]={firstPart}; paraValueDict[\"@{callSiteKey}\"][\"expr\"]=\"{initialCallName}\"\n'
                 #再保存API的参数值
-                dicString2=f'paraValueDict[\"{key}\"]=['
+                dicString2=f'paraValueDict[\"{callSiteKey}\"]=['
                 paraLst=get_parameter(paraStr,space=0) #项目参数不去空格2023-12-14
                 for para in paraLst: 
                     if '=' in para and "'='" not in para and '"="' not in para: #若参数的形式为key=f(x=1),只要确保=的前面不含括号即可
@@ -621,6 +625,7 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
         spaceNum=0
         lineno=getImportLine(codeLst)
         codeLst.insert(lineno,'import dill\n')
+        codeLst.insert(lineno,'import os\n')
         codeLst.insert(lineno,'from codeUtils import *\n')
         mainLineno=0
         #计算__main__第一个非空行开头的空格数
@@ -660,80 +665,48 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
                 l-=1
         
         
-        s1="for key,value in paraValueDict.items():\n"
-        s2="if '@' in key:\n"
-        s3="continue\n"        
-        s4="tempDict={}\n"
-        s5="tempDict[key]=value\n"
-        s6="k='@{}'.format(key)\n"
-        s7="if k in paraValueDict:\n"
-        s8="tempDict[k]=paraValueDict[k]\n"
-        s9="pklName=getFileName(key,'.pkl')\n"
-        s10="try:\n"
-        s11=f"with open('{pklPrefix}"+"/{}'.format(pklName),'wb') as fw:\n"
-        s12="dill.dump(tempDict,fw)\n"
-        s13="except BaseException as e:\n"
-        s14="print('save to pkl error: {}'.format(e))\n"
-        s15=f"with open('{pklPrefix}/coverSet','w',encoding='utf-8') as fw:\n"
-        s16="for it in apiCoveredSet:\n"
-        s17="fw.write(it+'\\n')\n"  
-        #添加空格
-        #spaceNum不能为0,为0的时候，这个地方会出错，后面得修改一下,一个spaceNum就是一个tab块=4空格
-        if spaceNum!=0:
-            s1=' '*spaceNum*1+s1
-            s2=' '*spaceNum*2+s2
-            s3=' '*spaceNum*3+s3
-            s4=' '*spaceNum*2+s4
-            s5=' '*spaceNum*2+s5
-            s6=' '*spaceNum*2+s6
-            s7=' '*spaceNum*2+s7
-            s8=' '*spaceNum*3+s8
-            s9=' '*spaceNum*2+s9
-            s10=' '*spaceNum*2+s10
-            s11=' '*spaceNum*3+s11
-            s12=' '*spaceNum*4+s12
-            s13=' '*spaceNum*2+s13
-            s14=' '*spaceNum*3+s14
-
-            s15=' '*spaceNum*1+s15
-            s16=' '*spaceNum*2+s16
-            s17=' '*spaceNum*3+s17
-        else:
-            spaceNum=4
-            s2=' '*spaceNum*1+s2
-            s3=' '*spaceNum*2+s3
-            s4=' '*spaceNum*1+s4
-            s5=' '*spaceNum*1+s5
-            s6=' '*spaceNum*1+s6
-            s7=' '*spaceNum*1+s7
-            s8=' '*spaceNum*2+s8
-            s9=' '*spaceNum*1+s9
-            s10=' '*spaceNum*1+s10
-            s11=' '*spaceNum*2+s11
-            s12=' '*spaceNum*3+s12
-            s13=' '*spaceNum*1+s13
-            s14=' '*spaceNum*2+s14
-            
-            s16=' '*spaceNum*1+s16
-            s17=' '*spaceNum*2+s17
-
-        headLst.append(s1)
-        headLst.append(s2)
-        headLst.append(s3)
-        headLst.append(s4)
-        headLst.append(s5)
-        headLst.append(s6)
-        headLst.append(s7)
-        headLst.append(s8)
-        headLst.append(s9)
-        headLst.append(s10)
-        headLst.append(s11)
-        headLst.append(s12)
-        headLst.append(s13)
-        headLst.append(s14)
-        headLst.append(s15)
-        headLst.append(s16)
-        headLst.append(s17)
+        unit = spaceNum if spaceNum != 0 else 4
+        base = spaceNum if spaceNum != 0 else 0
+        # 每个候选pkl都保存完整的{callsite参数, @callsite接收者}，避免参数和接收者分属不同文件
+        saveLines = [
+            (0, "for key,value in paraValueDict.items():\n"),
+            (1, "if '@' in key:\n"),
+            (2, "continue\n"),
+            (1, "k='@{}'.format(key)\n"),
+            (1, "receiver=paraValueDict.get(k)\n"),
+            (1, "candidates=[]\n"),
+            (1, "if isinstance(receiver,dict) and ('object' in receiver or 'expr' in receiver):\n"),
+            (2, "if 'object' in receiver:\n"),
+            (3, "candidates.append(('__object',receiver['object']))\n"),
+            (2, "if 'expr' in receiver:\n"),
+            (3, "candidates.append(('__expr',receiver['expr']))\n"),
+            (1, "else:\n"),
+            (2, "candidates.append(('',receiver))\n"),
+            (1, "for suffix,receiverValue in candidates:\n"),
+            (2, "tempDict={}\n"),
+            (2, "tempDict[key]=value\n"),
+            (2, "if receiverValue is not None:\n"),
+            (3, "tempDict[k]=receiverValue\n"),
+            (2, "pklName=getFileName(key,'.pkl')\n"),
+            (2, "if suffix:\n"),
+            (3, "pklName=pklName[:-4]+suffix+'.pkl'\n"),
+            (2, "tmpPklName=pklName+'.tmp'\n"),
+            (2, "# 先写临时文件再原子替换，避免pickle失败时留下空pkl\n"),
+            (2, "try:\n"),
+            (3, f"with open('{pklPrefix}"+"/{}'.format(tmpPklName),'wb') as fw:\n"),
+            (4, "dill.dump(tempDict,fw)\n"),
+            (3, f"os.replace('{pklPrefix}"+"/{}'.format(tmpPklName),'"+f"{pklPrefix}"+"/{}'.format(pklName))\n"),
+            (2, "except BaseException as e:\n"),
+            (3, f"tmpPath='{pklPrefix}"+"/{}'.format(tmpPklName)\n"),
+            (3, "if os.path.exists(tmpPath):\n"),
+            (4, "os.remove(tmpPath)\n"),
+            (3, "print('save to pkl error: {}'.format(e))\n"),
+            (0, f"with open('{pklPrefix}/coverSet','w',encoding='utf-8') as fw:\n"),
+            (1, "for it in apiCoveredSet:\n"),
+            (2, "fw.write(it+'\\n')\n"),
+        ]
+        for level, text in saveLines:
+            headLst.append(' ' * (base + unit * level) + text)
 
         codeLst=headLst+trailLst    
     if codeLst[0]=='pass\n':
@@ -759,6 +732,7 @@ def handleRunFile(file,runPath,runCommand):
     lineno=getImportLine(codeLst)
     codeLst.insert(lineno,f"from recordValue import paraValueDict\n")
     codeLst.insert(lineno,'import dill\n')
+    codeLst.insert(lineno,'import os\n')
     #寻找__main__所在的行
     flag=0
     spaceNum=0
@@ -794,32 +768,43 @@ def handleRunFile(file,runPath,runCommand):
         while l>0:
             pklPrefix='../'+pklPrefix
             l-=1
-    s1="try:\n"
-    s2=f"with open('{pklPrefix}/paraValue.pkl','wb') as fw:\n"
-    s3="dill.dump(paraValueDict,fw)\n"
-    s4="except Exception as e:\n"
-    s5="print('save to pkl error: {}'.format(e))\n"
-    #spaceNum不能为0
-    if spaceNum: 
-        s1=' '*spaceNum*1+s1
-        s2=' '*spaceNum*2+s2
-        s3=' '*spaceNum*3+s3
-        s4=' '*spaceNum*1+s4
-        s5=' '*spaceNum*2+s5       
-    else:
-        spaceNum=4
-        s1=' '*spaceNum*0+s1
-        s2=' '*spaceNum*1+s2
-        s3=' '*spaceNum*2+s3
-        s4=' '*spaceNum*0+s4
-        s5=' '*spaceNum*1+s5       
-
-
-    headLst.append(s1)
-    headLst.append(s2)
-    headLst.append(s3)
-    headLst.append(s4)
-    headLst.append(s5)
+    unit = spaceNum if spaceNum != 0 else 4
+    base = spaceNum if spaceNum != 0 else 0
+    # 动态重生成pkl时先保存通用候选文件，Map阶段再改名为具体API调用点文件
+    saveLines = [
+        (0, "for key,value in paraValueDict.items():\n"),
+        (1, "if '@' in key:\n"),
+        (2, "continue\n"),
+        (1, "k='@{}'.format(key)\n"),
+        (1, "receiver=paraValueDict.get(k)\n"),
+        (1, "candidates=[]\n"),
+        (1, "if isinstance(receiver,dict) and ('object' in receiver or 'expr' in receiver):\n"),
+        (2, "if 'object' in receiver:\n"),
+        (3, "candidates.append(('__object',receiver['object']))\n"),
+        (2, "if 'expr' in receiver:\n"),
+        (3, "candidates.append(('__expr',receiver['expr']))\n"),
+        (1, "else:\n"),
+        (2, "candidates.append(('',receiver))\n"),
+        (1, "for suffix,receiverValue in candidates:\n"),
+        (2, "tempDict={}\n"),
+        (2, "tempDict[key]=value\n"),
+        (2, "if receiverValue is not None:\n"),
+        (3, "tempDict[k]=receiverValue\n"),
+        (2, "pklName='paraValue'+suffix+'.pkl'\n"),
+        (2, "tmpPklName=pklName+'.tmp'\n"),
+        (2, "# 先写临时文件再原子替换，避免pickle失败时留下空pkl\n"),
+        (2, "try:\n"),
+        (3, f"with open('{pklPrefix}"+"/{}'.format(tmpPklName),'wb') as fw:\n"),
+        (4, "dill.dump(tempDict,fw)\n"),
+        (3, f"os.replace('{pklPrefix}"+"/{}'.format(tmpPklName),'"+f"{pklPrefix}"+"/{}'.format(pklName))\n"),
+        (2, "except BaseException as e:\n"),
+        (3, f"tmpPath='{pklPrefix}"+"/{}'.format(tmpPklName)\n"),
+        (3, "if os.path.exists(tmpPath):\n"),
+        (4, "os.remove(tmpPath)\n"),
+        (3, "print('save to pkl error: {}'.format(e))\n"),
+    ]
+    for level, text in saveLines:
+        headLst.append(' ' * (base + unit * level) + text)
 
     codeLst=headLst+trailLst
 

--- a/Preprocess/preprocess.py
+++ b/Preprocess/preprocess.py
@@ -626,6 +626,7 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
         lineno=getImportLine(codeLst)
         codeLst.insert(lineno,'import dill\n')
         codeLst.insert(lineno,'import os\n')
+        codeLst.insert(lineno,'import json\n')
         codeLst.insert(lineno,'from codeUtils import *\n')
         mainLineno=0
         #计算__main__第一个非空行开头的空格数
@@ -675,6 +676,8 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
             (1, "k='@{}'.format(key)\n"),
             (1, "receiver=paraValueDict.get(k)\n"),
             (1, "candidates=[]\n"),
+            (1, "candidateManifest={'callsite':key,'covered':True,'candidates':[]}\n"),
+            (1, "manifestName=getFileName(key,'.manifest.json')\n"),
             (1, "if isinstance(receiver,dict) and ('object' in receiver or 'expr' in receiver):\n"),
             (2, "if 'object' in receiver:\n"),
             (3, "candidates.append(('__object',receiver['object']))\n"),
@@ -683,6 +686,9 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
             (1, "else:\n"),
             (2, "candidates.append(('',receiver))\n"),
             (1, "for suffix,receiverValue in candidates:\n"),
+            (2, "candidateKind=suffix[2:] if suffix else 'object'\n"),
+            (2, "candidateInfo={'callsite':key,'kind':candidateKind,'status':'pending','pkl':None}\n"),
+            (2, "candidateInfo['callsite']=key\n"),
             (2, "tempDict={}\n"),
             (2, "tempDict[key]=value\n"),
             (2, "if receiverValue is not None:\n"),
@@ -690,17 +696,24 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
             (2, "pklName=getFileName(key,'.pkl')\n"),
             (2, "if suffix:\n"),
             (3, "pklName=pklName[:-4]+suffix+'.pkl'\n"),
+            (2, "candidateInfo['pkl']=pklName\n"),
             (2, "tmpPklName=pklName+'.tmp'\n"),
             (2, "# 先写临时文件再原子替换，避免pickle失败时留下空pkl\n"),
             (2, "try:\n"),
             (3, f"with open('{pklPrefix}"+"/{}'.format(tmpPklName),'wb') as fw:\n"),
             (4, "dill.dump(tempDict,fw)\n"),
             (3, f"os.replace('{pklPrefix}"+"/{}'.format(tmpPklName),'"+f"{pklPrefix}"+"/{}'.format(pklName))\n"),
+            (3, "candidateInfo['status']='saved'\n"),
             (2, "except BaseException as e:\n"),
             (3, f"tmpPath='{pklPrefix}"+"/{}'.format(tmpPklName)\n"),
             (3, "if os.path.exists(tmpPath):\n"),
             (4, "os.remove(tmpPath)\n"),
+            (3, "candidateInfo['status']='save_failed'\n"),
+            (3, "candidateInfo['error']=str(e)\n"),
             (3, "print('save to pkl error: {}'.format(e))\n"),
+            (2, "candidateManifest['candidates'].append(candidateInfo)\n"),
+            (1, f"with open('{pklPrefix}"+"/{}'.format(manifestName),'w',encoding='utf-8') as fw:\n"),
+            (2, "json.dump(candidateManifest,fw,indent=4,ensure_ascii=False)\n"),
             (0, f"with open('{pklPrefix}/coverSet','w',encoding='utf-8') as fw:\n"),
             (1, "for it in apiCoveredSet:\n"),
             (2, "fw.write(it+'\\n')\n"),
@@ -733,6 +746,8 @@ def handleRunFile(file,runPath,runCommand):
     codeLst.insert(lineno,f"from recordValue import paraValueDict\n")
     codeLst.insert(lineno,'import dill\n')
     codeLst.insert(lineno,'import os\n')
+    codeLst.insert(lineno,'import json\n')
+    codeLst.insert(lineno,'from codeUtils import *\n')
     #寻找__main__所在的行
     flag=0
     spaceNum=0
@@ -778,6 +793,8 @@ def handleRunFile(file,runPath,runCommand):
         (1, "k='@{}'.format(key)\n"),
         (1, "receiver=paraValueDict.get(k)\n"),
         (1, "candidates=[]\n"),
+        (1, "candidateManifest={'callsite':key,'covered':True,'candidates':[]}\n"),
+        (1, "manifestName=getFileName(key,'.manifest.json')\n"),
         (1, "if isinstance(receiver,dict) and ('object' in receiver or 'expr' in receiver):\n"),
         (2, "if 'object' in receiver:\n"),
         (3, "candidates.append(('__object',receiver['object']))\n"),
@@ -786,22 +803,32 @@ def handleRunFile(file,runPath,runCommand):
         (1, "else:\n"),
         (2, "candidates.append(('',receiver))\n"),
         (1, "for suffix,receiverValue in candidates:\n"),
+        (2, "candidateKind=suffix[2:] if suffix else 'object'\n"),
+        (2, "candidateInfo={'callsite':key,'kind':candidateKind,'status':'pending','pkl':None}\n"),
+        (2, "candidateInfo['callsite']=key\n"),
         (2, "tempDict={}\n"),
         (2, "tempDict[key]=value\n"),
         (2, "if receiverValue is not None:\n"),
         (3, "tempDict[k]=receiverValue\n"),
         (2, "pklName='paraValue'+suffix+'.pkl'\n"),
+        (2, "candidateInfo['pkl']=pklName\n"),
         (2, "tmpPklName=pklName+'.tmp'\n"),
         (2, "# 先写临时文件再原子替换，避免pickle失败时留下空pkl\n"),
         (2, "try:\n"),
         (3, f"with open('{pklPrefix}"+"/{}'.format(tmpPklName),'wb') as fw:\n"),
         (4, "dill.dump(tempDict,fw)\n"),
         (3, f"os.replace('{pklPrefix}"+"/{}'.format(tmpPklName),'"+f"{pklPrefix}"+"/{}'.format(pklName))\n"),
+        (3, "candidateInfo['status']='saved'\n"),
         (2, "except BaseException as e:\n"),
         (3, f"tmpPath='{pklPrefix}"+"/{}'.format(tmpPklName)\n"),
         (3, "if os.path.exists(tmpPath):\n"),
         (4, "os.remove(tmpPath)\n"),
+        (3, "candidateInfo['status']='save_failed'\n"),
+        (3, "candidateInfo['error']=str(e)\n"),
         (3, "print('save to pkl error: {}'.format(e))\n"),
+        (2, "candidateManifest['candidates'].append(candidateInfo)\n"),
+        (1, f"with open('{pklPrefix}"+"/{}'.format(manifestName),'w',encoding='utf-8') as fw:\n"),
+        (2, "json.dump(candidateManifest,fw,indent=4,ensure_ascii=False)\n"),
     ]
     for level, text in saveLines:
         headLst.append(' ' * (base + unit * level) + text)
@@ -1162,6 +1189,8 @@ def codeProcess(projPath,runCommand,runPath,libName):
         file=f'Copy/bak_{projName}/{prefix}/'+file
         # print(prefix)
         handleRunFile(file,runPath,runCommand) 
+    # bak项目会在current pkl生成后换回Copy/{projName}，其运行文件也依赖codeUtils
+    shutil.copy2('Script/codeUtils.py',f'Copy/bak_{projName}/{prefix}')
     
     #处理完项目所有文件后，再给项目添加一个新的文件
     # with open(f"Copy/{projName}/{prefix}/recordValue.py",'w') as fw:

--- a/Repair/repair.py
+++ b/Repair/repair.py
@@ -265,15 +265,25 @@ def fix(callAPI,repairDict,node,starFlag,twoStarFlag):
 #  @param runPath The relative path of the run file
 #  @param runCommand The run command of the project
 #  @return result Dynamic validation result
-def validateByRun(callAPI,apiWithValue,projName,virtualEnv,runPath,runCommand):
+def validateByRun(callAPI,apiWithValue,projName,virtualEnv,runPath,runCommand,callKey=None):
     if apiWithValue=='':
         return None
-    pklName=getFileName(callAPI,'.pkl')
-    if os.path.exists(f"Copy/pkl/new_{pklName}"): #优先加载新版本的PKL
-        pklPath=f"../../Copy/pkl/new_{pklName}"
-    elif os.path.exists(f'Copy/pkl/{pklName}'):
-        pklPath=f"../../Copy/pkl/{pklName}"
-    else:
+    pklName=getFileName(callKey or callAPI,'.pkl')
+    # 验证阶段复用候选pkl顺序，保证修复验证和动态匹配读取的是同一类接收者
+    pklCandidates=[
+        'new_'+pklName[:-4]+'__object.pkl',
+        'new_'+pklName[:-4]+'__expr.pkl',
+        'new_'+pklName,
+        pklName[:-4]+'__object.pkl',
+        pklName[:-4]+'__expr.pkl',
+        pklName,
+    ]
+    pklPath=''
+    for candidateName in pklCandidates:
+        if os.path.exists(f"Copy/pkl/{candidateName}"):
+            pklPath=f"../../Copy/pkl/{candidateName}"
+            break
+    if not pklPath:
         return None
 
     #当runPath不在runCommand中时，需要切换到运行文件所在的目录执行命令
@@ -359,7 +369,7 @@ def validateByStr(fixedAPI,repairDict,targetAPIDefinition,starFlag,twoStarFlag):
 #  @param virtualEnv The virtual environment of the target lib version
 #  @param errLst List of error messages
 #  @return repairResults 
-def repairTask(root,callAPI,apiWithValue,projName,runPath,runCommand,repairLst,virtualEnv,errLst):
+def repairTask(root,callAPI,apiWithValue,projName,runPath,runCommand,repairLst,virtualEnv,errLst,callKey=None):
     #静态修复,pkl加载失败，只能进入静态修复
     repairCandidates=[]
     if apiWithValue=='':
@@ -413,7 +423,7 @@ def repairTask(root,callAPI,apiWithValue,projName,runPath,runCommand,repairLst,v
         fix(apiWithValue,repairDict,apiRoot,starFlag,twoStarFlag)
         apiWithValueFixed=ast.unparse(apiRoot)
         #1先通过动态运行,判断其是否修复成功
-        result=validateByRun(callAPI,apiWithValueFixed,projName,virtualEnv,runPath,runCommand)
+        result=validateByRun(callAPI,apiWithValueFixed,projName,virtualEnv,runPath,runCommand,callKey)
         if result==None:
             if fixedAPI not in repairCandidates:
                 repairCandidates.append(fixedAPI)

--- a/Script/addValueForAPI.py
+++ b/Script/addValueForAPI.py
@@ -18,6 +18,7 @@ print("load pkl successfully")
 
 
 callAPI=sys.argv[2]
+lookupKey=sys.argv[3] if len(sys.argv)>3 else callAPI
 lst1=departAPI(callAPI) #将API按点进行拆分a.b(y).c(z)拆分成a.b(y), a.b(y).c(z)
 lst2=departAPI2(callAPI) #拆分成a(x), b(y), c(z)
 tempLst=[]
@@ -26,7 +27,7 @@ s=''
 #给API填上参数的具体值
 for key in paraValueDict.keys():
     #if callAPI.replace(' ','')==key.replace(' ',''):
-    if getFileName(callAPI,'')==getFileName(key,''): # 2025/5/25 Fix inconsistency between callAPI name and the key name
+    if getFileName(lookupKey,'')==getFileName(key,''): # 2025/5/25 Fix inconsistency between callAPI name and the key name
         # 2025/5/25 将复杂API参数键替换为简单键，例如复杂的引号符号
         newKey = "callKey"  
         if newKey not in paraValueDict:
@@ -56,12 +57,23 @@ for key in paraValueDict.keys():
         k='@{}'.format(key)
         firstPart=lst2[0]    
         if k in paraValueDict:
+            receiver = paraValueDict.get(k)
+            # 新版withitem pkl可能保存object/expr候选；旧版pkl仍是单个接收者
+            if isinstance(receiver, dict):
+                if 'object' in receiver:
+                    receiver = receiver['object']
+                elif 'expr' in receiver:
+                    receiver = receiver['expr']
+                paraValueDict[k] = receiver
             # 2025/5/25 将复杂API参数键替换为简单键，例如复杂的引号符号
             newK = '@' + newKey 
             if newK not in paraValueDict:
-                paraValueDict[newK] = paraValueDict[k] 
+                paraValueDict[newK] = receiver 
 
-            s='paraValueDict["{}"]'.format(newK)+'.'+s
+            if isinstance(receiver, str):
+                s=receiver+'.'+s
+            else:
+                s='paraValueDict["{}"]'.format(newK)+'.'+s
         else:#比如torch.func(x),还有类似于tornado.web.Application()的形式
             prefix=''
             for it in lst2:

--- a/Script/dynamicMatch.py
+++ b/Script/dynamicMatch.py
@@ -24,6 +24,7 @@ print("load pkl successfully")
 #step2: 动态匹配
 callAPI=sys.argv[2]
 jsonPrefix=sys.argv[3]
+lookupKey=sys.argv[4] if len(sys.argv)>4 else callAPI
 matchDict={}
 tempLst=[]
 s=''
@@ -37,14 +38,22 @@ s=removeParameter(lastAPI,1)
 for key in paraValueDict.keys():
     #if callAPI.replace(' ','')==key.replace(' ',''):
     # 2025/5/25 Fix inconsistency between callAPI name and the key name
-    if getFileName(callAPI,'')==getFileName(key,''): 
+    if getFileName(lookupKey,'')==getFileName(key,''): 
         #把函数的上文依赖给填上,比如self.a(x)中的self, a.b(2).c(3)中的a.b(2)
         k='@{}'.format(key)
         firstPart=lst2[0]
         if k in paraValueDict:
-            #新增类Contenxt Manager对象动态匹配支持 -- 2025/5/20
-            if isinstance(eval('paraValueDict.get(k)'),str):
-                s=eval('paraValueDict.get(k)')+'.'+s
+            #新增Context Manager对象动态匹配支持 -- 2025/5/20
+            receiver = paraValueDict.get(k)
+            # 新版withitem pkl可能保存object/expr候选；旧版pkl仍是单个接收者
+            if isinstance(receiver, dict):
+                if 'object' in receiver:
+                    receiver = receiver['object']
+                elif 'expr' in receiver:
+                    receiver = receiver['expr']
+                paraValueDict[k] = receiver
+            if isinstance(receiver,str):
+                s=receiver+'.'+s
             else:
                 s='paraValueDict.get(k)'+'.'+s
         else: #比如torch.func(x),还有类似于tornado.web.Application()的形式
@@ -80,7 +89,7 @@ except Exception as e:
 
 # print("match:",matchDict['match'])
 #动态匹配若失败，则没有internalPath,和addValue这两个属性的
-fileName=getFileName(callAPI,'_dynamicMatch.json')
+fileName=getFileName(lookupKey,'_dynamicMatch.json')
 
 with open('{}/data/{}'.format(jsonPrefix,fileName),'w',encoding='UTF-8') as fw:
     json.dump(matchDict,fw,indent=4,ensure_ascii=False)

--- a/main.py
+++ b/main.py
@@ -62,6 +62,8 @@ def backwardTask(args):
         ansDict[key]={}
         callAPI=key.split('#_')[0]
         lineNum=key.split('#_')[1]
+        # 动态阶段使用调用点key区分同名API，避免不同调用行共享同一个pkl和缓存结果
+        callKey=f"{getFileName(callAPI,'')}#_{lineNum}"
         ansDict[key]['Location']=f"At Line {lineNum} in {fileRelativePath}"
         #判断有没有覆盖有两个条件，先看是否有pkl，再看是否在coverSet中
         # if not os.path.exists(f"Copy/pkl/{pklName}") and f"{fileName}##{lineNum}##{callAPI}".replace(' ','') not in coverSet:
@@ -87,15 +89,15 @@ def backwardTask(args):
         #step3:将项目中的API与库API进行匹配，获得参数定义
         #首先判断一下这个API是否匹配过，若之前匹配过了，就不用再匹配了
         with lock:
-            matchDict=querySharedDict(callAPI,sharedDict) #当查询操作发生在更新操作之前，可能会查询失败
+            matchDict=querySharedDict(callKey,sharedDict) #当查询操作发生在更新操作之前，可能会查询失败
         if len(matchDict)>0:
             currentMatch=matchDict['current']
             targetMatch=matchDict['target']
         else:
-            currentMatch=mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,currentVersion,currentEnv,lock,errLst)
-            targetMatch=mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,targetVersion,targetEnv,lock,errLst,curr=0)
+            currentMatch=mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,currentVersion,currentEnv,lock,errLst,callKey=callKey)
+            targetMatch=mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,targetVersion,targetEnv,lock,errLst,curr=0,callKey=callKey)
             with lock:
-                updateSharedDict(callAPI,currentMatch,targetMatch,sharedDict)#更新sharedDict
+                updateSharedDict(callKey,currentMatch,targetMatch,sharedDict)#更新sharedDict
         
         
         ansDict[key][f"Definition @{currentVersion} <{currentMatch['matchMethod']}>"]=str(currentMatch['match'])
@@ -115,8 +117,8 @@ def backwardTask(args):
         if len(repairLst)==0: #若返回修复字典的个数为零，则一定是兼容的
             ansDict[key]['Compatible']='Yes'
         else:
-            apiWithValue=addValueForAPI(callAPI,projName,runPath,runCommand,currentEnv,targetEnv,errLst) #apiWithValue为空表示添加参数失败
-            fixedAPI,compatibilityLabel,repairStatus=repairTask(root,callAPI,apiWithValue,projName,runPath,runCommand,repairLst,targetEnv,errLst)
+            apiWithValue=addValueForAPI(callAPI,projName,runPath,runCommand,currentEnv,targetEnv,errLst,callKey=callKey) #apiWithValue为空表示添加参数失败
+            fixedAPI,compatibilityLabel,repairStatus=repairTask(root,callAPI,apiWithValue,projName,runPath,runCommand,repairLst,targetEnv,errLst,callKey=callKey)
             if compatibilityLabel=='Compatible':
                 ansDict[key]['Compatible']='Yes'
             else:


### PR DESCRIPTION
## Summary

This PR improves dynamic receiver matching when runtime values cannot be pickled.

- Record candidate save manifests so callsites that were covered but failed to dump pkl files can still trigger target-environment regeneration.
- Keep `codeUtils.py` available in the restored `Copy/bak_*` run tree used during target regeneration.
- Add expression candidates for statically resolved receiver aliases, including scoped assignment receivers and inherited `self` receivers.
- Preserve object-first matching while allowing expression fallback when object serialization fails.

## Root Cause

Some callsites were covered at runtime but their pkl dump failed because the receiver or parameter values were not serializable. Since failed dumps previously left no pkl artifact, target dynamic matching treated the callsite as unavailable and fell back to static matching instead of regenerating the pkl in the target environment.


