### PR TITLE
Add isolated run workspace for PCART runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 __pycache__/
-data/
 Report/
 Configure/
-Dynamic/
-Copy/
+PCARTRuns/
 Example/
 log
 *test*

--- a/Load/loadData.py
+++ b/Load/loadData.py
@@ -5,6 +5,7 @@
 
 
 
+import os
 import re
 import json
 from Path.getPath import Path
@@ -22,8 +23,10 @@ from Tool.tool import cmp
 #  @return assignDict The assign dict stores the alias of APIs
 #  @return libAPIins The built-in APIs' definitions 
 def loadLib(libName,version):
-    # f=open(f'LibAPIExtraction/{libName}/{libName}{version}','r')
-    f = open(f'LibAPIExtraction/{libName}/{libName}{version}', 'r', encoding='utf-8')
+    # 使用源码位置定位仓库根目录，避免切换运行工作区后找不到LibAPIExtraction
+    repoRoot=os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    libPath=os.path.join(repoRoot,'LibAPIExtraction',libName,f'{libName}{version}')
+    f = open(libPath, 'r', encoding='utf-8')
     lst=f.readlines()
     f.close()
     libAPIs=[] #既包含了非内置也包含了内置

--- a/Preprocess/preprocess.py
+++ b/Preprocess/preprocess.py
@@ -986,6 +986,16 @@ def writeRecordValue(filePath,pklRelPath,useCallsiteName):
         fw.write(content)
 
 
+## Get source script path from PCART repository
+## 获取PCART仓库中的辅助脚本路径
+#
+#  @param scriptName The script file name under Script/
+#  @return Absolute script path
+def scriptPath(scriptName):
+    return os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        'Script',scriptName)
+
+
 ## Code processing
 ## 代码预处理
 #
@@ -1045,10 +1055,10 @@ def codeProcess(projPath,runCommand,runPath,libName):
     #去掉项目代码中的冗余信息，仅保存项目代码的结构信息（import,functionDef, classDef）
     saveStructure(f'Dynamic/{projName}',libName) 
     
-    shutil.copy2('Script/addValueForAPI.py',f'Dynamic/{projName}/{prefix}')
-    shutil.copy2('Script/codeUtils.py',f'Dynamic/{projName}/{prefix}')
-    shutil.copy2('Script/dynamicMatch.py',f'Dynamic/{projName}/{prefix}')
-    shutil.copy2('Script/verifySingle.py',f'Dynamic/{projName}/{prefix}')
+    shutil.copy2(scriptPath('addValueForAPI.py'),f'Dynamic/{projName}/{prefix}')
+    shutil.copy2(scriptPath('codeUtils.py'),f'Dynamic/{projName}/{prefix}')
+    shutil.copy2(scriptPath('dynamicMatch.py'),f'Dynamic/{projName}/{prefix}')
+    shutil.copy2(scriptPath('verifySingle.py'),f'Dynamic/{projName}/{prefix}')
     
     #更新脚本中的from ... import ...语句,因为加载pkl的时候需要依赖于项目的结构信息
     modifyFromImport(f'Dynamic/{projName}/{prefix}/addValueForAPI.py',libImportLst)
@@ -1100,11 +1110,11 @@ def codeProcess(projPath,runCommand,runPath,libName):
         # print(prefix)
         handleRunFile(file,runPath,runCommand) 
     # bak项目会在current pkl生成后换回Copy/{projName}，其运行文件也依赖codeUtils
-    shutil.copy2('Script/codeUtils.py',f'Copy/bak_{projName}/{prefix}')
+    shutil.copy2(scriptPath('codeUtils.py'),f'Copy/bak_{projName}/{prefix}')
     
     #处理完项目所有文件后，再给项目添加一个新的文件
     writeRecordValue(f"Copy/{projName}/{prefix}/recordValue.py",pklRelPath,1)
     
-    shutil.copy2('Script/codeUtils.py',f'Copy/{projName}/{runPath}') 
+    shutil.copy2(scriptPath('codeUtils.py'),f'Copy/{projName}/{runPath}')
     if prefix!=runPath:
-        shutil.copy2('Script/codeUtils.py',f'Copy/{projName}/{prefix}')
+        shutil.copy2(scriptPath('codeUtils.py'),f'Copy/{projName}/{prefix}')

--- a/Tool/tool.py
+++ b/Tool/tool.py
@@ -561,6 +561,37 @@ def loadConfig(configPath):
     return dic['projPath'],runCommand,dic['runFilePath'],dic['libName'],dic['currentVersion'],dic['targetVersion'],dic['currentEnv'],dic['targetEnv']
 
 
+## Resolve PCART config file path
+## 解析PCART配置文件路径
+#
+#  @param config The config file path or config file name under Configure
+#  @param repoRoot The PCART repository root path
+#  @return Absolute config file path
+def resolveConfigFilePath(config,repoRoot):
+    if os.path.isabs(config):
+        return config
+    if os.path.exists(config):
+        return os.path.abspath(config)
+    return os.path.join(repoRoot,'Configure',config)
+
+
+## Resolve path value loaded from PCART config
+## 解析PCART配置字段中的路径值
+#
+#  @param repoRoot The PCART repository root path
+#  @param path The path value read from config
+#  @return Absolute path for relative values, original empty value otherwise
+def resolveConfigValuePath(repoRoot,path):
+    if not path:
+        return path
+    expanded=os.path.expanduser(path)
+    if os.name=='nt' and expanded.startswith('/') and not expanded.startswith('//'):
+        return expanded
+    if os.path.isabs(expanded):
+        return os.path.abspath(expanded)
+    return os.path.abspath(os.path.join(repoRoot,expanded))
+
+
 class UnsupportedRunCommand(Exception):
     """Raised when PCART cannot safely execute a configured run command."""
 

--- a/Tool/workspace.py
+++ b/Tool/workspace.py
@@ -1,0 +1,219 @@
+## @package workspace
+#  Run workspace helpers for isolating PCART execution artifacts
+#  提供PCART运行工作区的创建、编号、元数据记录和报告导出能力
+
+
+import json
+import os
+import re
+import shutil
+from contextlib import contextmanager
+from dataclasses import asdict,dataclass
+from datetime import datetime
+
+
+## Run workspace path object
+## PCART单次运行的工作区路径对象
+#
+#  This object keeps all paths generated for one command execution.
+#  该对象集中保存一次命令执行产生的所有运行目录。
+@dataclass
+class RunWorkspace:
+    repo_root: str
+    run_id: str
+    command_id: str
+    run_root: str
+    workspace_root: str
+    copy_root: str
+    dynamic_root: str
+    data_dir: str
+    temp_dir: str
+    internal_report_dir: str
+    report_root: str
+    metadata_path: str
+
+
+## Get PCART repository root path
+## 获取PCART仓库根目录路径
+#
+#  @return The absolute repository root path
+def getRepoRoot():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+## Convert project path/name to a filesystem-safe slug
+## 将项目路径或项目名转换为可作为目录名使用的slug
+#
+#  @param projPath The project path or project name
+#  @return A safe project slug used in run id
+def slugifyProjectName(projPath):
+    normalized=str(projPath).strip().rstrip('/\\')
+    if not normalized:
+        return 'project'
+    name=re.split(r'[\\/]+',normalized)[-1]
+    slug=re.sub(r'[^A-Za-z0-9._-]+','-',name).strip('.-_')
+    return slug or 'project'
+
+
+## Allocate next run id under runs root
+## 在运行目录下分配下一个run id
+#
+#  The directory is created with os.mkdir so concurrent PCART processes do not
+#  acquire the same id.
+#  通过os.mkdir原子创建目录，避免并发运行获取到相同编号。
+#
+#  @param runsRoot The root directory containing all run instances
+#  @param projectSlug The safe project slug
+#  @param timestamp Timestamp string used in run id
+#  @return (runId, runRoot) tuple
+def _nextRunId(runsRoot,projectSlug,timestamp):
+    prefix=f'{projectSlug}__{timestamp}'
+    for index in range(1, 1000):
+        runId=f'{prefix}-{index:03d}'
+        runRoot=os.path.join(runsRoot,runId)
+        try:
+            os.mkdir(runRoot)
+            return runId, runRoot
+        except FileExistsError:
+            continue
+    raise RuntimeError(f'Cannot allocate run id for {prefix}')
+
+
+## Create an isolated workspace for one PCART run command
+## 为一次PCART运行命令创建隔离工作区
+#
+#  The workspace stores intermediate Copy/Dynamic/data/temp/Report artifacts
+#  under PCARTRuns, while user-visible reports are exported under Report/runs.
+#  运行中间态保存在PCARTRuns中，用户可见报告导出到Report/runs中。
+#
+#  @param repoRoot The PCART repository root path
+#  @param projPath The project path under test
+#  @param runCommand The project run command
+#  @param runPath The relative path of the run file
+#  @param libName The upgraded Python third-party library name
+#  @param currentVersion The current library version
+#  @param targetVersion The target library version
+#  @param currentEnv The virtual environment for current library version
+#  @param targetEnv The virtual environment for target library version
+#  @param commandId The command id under this run, default cmd-001
+#  @param timestamp Optional timestamp, mainly used by tests
+#  @return RunWorkspace object
+def createRunWorkspace(
+    repoRoot,
+    projPath,
+    runCommand,
+    runPath,
+    libName,
+    currentVersion,
+    targetVersion,
+    currentEnv,
+    targetEnv,
+    commandId='cmd-001',
+    timestamp=None,
+):
+    repoRoot=os.path.abspath(repoRoot)
+    timestamp=timestamp or datetime.now().strftime('%Y%m%d-%H%M%S')
+    projectSlug=slugifyProjectName(projPath)
+    runsRoot=os.path.join(repoRoot,'PCARTRuns','runs')
+    os.makedirs(runsRoot, exist_ok=True)
+    runId,runRoot=_nextRunId(runsRoot,projectSlug,timestamp)
+
+    workspaceRoot=os.path.join(runRoot,commandId)
+    os.mkdir(workspaceRoot)
+    copyRoot=os.path.join(workspaceRoot,'Copy')
+    dynamicRoot=os.path.join(workspaceRoot,'Dynamic')
+    dataDir=os.path.join(workspaceRoot,'data')
+    tempDir=os.path.join(workspaceRoot,'temp')
+    internalReportDir=os.path.join(workspaceRoot,'Report')
+    reportRoot=os.path.join(repoRoot,'Report','runs',runId,commandId)
+    metadataPath=os.path.join(workspaceRoot,'metadata.json')
+
+    for path in (
+        copyRoot,
+        dynamicRoot,
+        dataDir,
+        tempDir,
+        internalReportDir,
+        reportRoot,
+        os.path.join(reportRoot,'patches'),
+        os.path.join(reportRoot,'fixed_project'),
+    ):
+        os.makedirs(path,exist_ok=True)
+
+    workspace=RunWorkspace(
+        repo_root=repoRoot,
+        run_id=runId,
+        command_id=commandId,
+        run_root=runRoot,
+        workspace_root=workspaceRoot,
+        copy_root=copyRoot,
+        dynamic_root=dynamicRoot,
+        data_dir=dataDir,
+        temp_dir=tempDir,
+        internal_report_dir=internalReportDir,
+        report_root=reportRoot,
+        metadata_path=metadataPath,
+    )
+    writeMetadata(
+        workspace,
+        {
+            'project_slug': projectSlug,
+            'project_path': projPath,
+            'run_command': runCommand,
+            'run_file_path': runPath,
+            'lib_name': libName,
+            'current_version': currentVersion,
+            'target_version': targetVersion,
+            'current_env': currentEnv,
+            'target_env': targetEnv,
+        },
+    )
+    return workspace
+
+
+## Write workspace metadata
+## 写入运行工作区元数据
+#
+#  @param workspace The RunWorkspace object
+#  @param metadata Additional metadata collected from config
+def writeMetadata(workspace,metadata):
+    content=asdict(workspace)
+    content.update(metadata)
+    with open(workspace.metadata_path,'w',encoding='utf-8') as fw:
+        json.dump(content,fw,ensure_ascii=False,indent=2)
+
+
+## Temporarily switch current working directory
+## 临时切换当前工作目录
+#
+#  @param path The working directory used during the context
+@contextmanager
+def workspaceCwd(path):
+    previous=os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+## Export internal report files to user-visible report directory
+## 将工作区内部报告导出到用户可见报告目录
+#
+#  @param workspace The RunWorkspace object
+def exportRunReport(workspace):
+    os.makedirs(workspace.report_root, exist_ok=True)
+    os.makedirs(os.path.join(workspace.report_root,'patches'),exist_ok=True)
+    os.makedirs(os.path.join(workspace.report_root,'fixed_project'),exist_ok=True)
+    if not os.path.isdir(workspace.internal_report_dir):
+        return
+    for name in os.listdir(workspace.internal_report_dir):
+        source=os.path.join(workspace.internal_report_dir,name)
+        target=os.path.join(workspace.report_root,name)
+        if os.path.isdir(source):
+            if os.path.exists(target):
+                shutil.rmtree(target)
+            shutil.copytree(source,target)
+        else:
+            shutil.copy2(source,target)
+

--- a/main.py
+++ b/main.py
@@ -18,7 +18,8 @@ from multiprocessing import Manager
 from Extract.getCall import getCallFunction
 from Preprocess.preprocess import codeProcess
 from Repair.repair import repairTask,validateByRun
-from Tool.tool import getAst,save2txt,loadConfig,removeParameter,getFileName,buildRunCommand
+from Tool.tool import getAst,save2txt,loadConfig,removeParameter,getFileName,buildRunCommand,resolveConfigFilePath,resolveConfigValuePath
+from Tool.workspace import createRunWorkspace,exportRunReport,getRepoRoot,workspaceCwd
 from Change.changeAnalyze import isCompatible,addValueForAPI,updateSharedDict,querySharedDict,updateErrorLst
 
 
@@ -200,12 +201,13 @@ def backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,
     #print(createResult.stdout)
      
     #生成pkl成功后，将项目恢复成原样，便于之后对其中某个API单独插桩
-    # shutil.move(f'Copy/{projName}','temp')
-    shutil.move(os.path.join('Copy', projName), 'temp')
-    # shutil.move(f'Copy/bak_{projName}',f'Copy/{projName}')
+    os.makedirs('temp',exist_ok=True)
+    tempProjPath=os.path.join('temp',projName)
+    if os.path.exists(tempProjPath):
+        shutil.rmtree(tempProjPath)
+    shutil.move(os.path.join('Copy', projName), tempProjPath)
     shutil.move(os.path.join('Copy', f'bak_{projName}'), os.path.join('Copy', projName))
-    # shutil.move('temp',f'Copy/bak_{projName}')
-    shutil.move('temp', os.path.join('Copy', f'bak_{projName}'))
+    shutil.move(tempProjPath, os.path.join('Copy', f'bak_{projName}'))
 
 
     # dir=f"Report/{projName}/{libName}"
@@ -234,6 +236,52 @@ def backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,
     save2txt(resultLst, libName, runCommand, os.path.join('Report', f'{projName}.txt'))
 
 
+## Run PCART with an isolated workspace
+## 在隔离工作区中运行PCART
+#
+#  This function keeps old config fields unchanged, creates a RunWorkspace,
+#  runs preprocessing and analysis inside the workspace, then exports reports.
+#  该函数保持旧配置字段不变，创建运行工作区，在工作区内完成预处理和分析，
+#  最后导出用户可见报告。
+#
+#  @param config The config file path or config file name under Configure
+#  @return RunWorkspace object for this execution
+def run(config):
+    repoRoot=getRepoRoot()
+    configPath=resolveConfigFilePath(config,repoRoot)
+
+    #加载配置
+    projPath,runCommand,runPath,libName,currentVersion,targetVersion,currentEnv,targetEnv=loadConfig(configPath)
+    projPath=resolveConfigValuePath(repoRoot,projPath)
+    currentEnv=resolveConfigValuePath(repoRoot,currentEnv)
+    targetEnv=resolveConfigValuePath(repoRoot,targetEnv)
+
+    workspace=createRunWorkspace(
+        repoRoot,
+        projPath,
+        runCommand,
+        runPath,
+        libName,
+        currentVersion,
+        targetVersion,
+        currentEnv,
+        targetEnv,
+    )
+    print(f"Run workspace: {workspace.workspace_root}")
+    print("Code preprocessing...")
+
+    with workspaceCwd(workspace.workspace_root):
+        #首先对代码进行预处理
+        codeProcess(projPath,runCommand,runPath,libName)
+        print("Code preprocess complete")
+
+        #执行主逻辑
+        backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,runCommand,runPath)
+
+    exportRunReport(workspace)
+    print(f"Report output: {workspace.report_root}")
+    return workspace
+
 
 ## Main function of PCART
 ## PCART主函数
@@ -245,16 +293,7 @@ def main():
     config=sys.argv[2]
     start=time.time()
 
-    #加载配置
-    projPath,runCommand,runPath,libName,currentVersion,targetVersion,currentEnv,targetEnv=loadConfig(f'Configure/{config}')
-    print("Code preprocessing...")
-
-    #首先对代码进行预处理
-    codeProcess(projPath,runCommand,runPath,libName) 
-    print("Code preprocess complete")
-
-    #执行主逻辑 
-    backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,runCommand,runPath)
+    run(config)
 
     end=time.time()
     print(f"Total run time={int(end-start)}s")


### PR DESCRIPTION
## Summary

- Add per-run isolated workspaces under `PCARTRuns/runs/<run-id>/cmd-001/` for `Copy`, `Dynamic`, `data`, `temp`, and internal reports.
- Export user-facing reports to `Report/runs/<run-id>/cmd-001/`.
- Resolve config paths before switching cwd and keep PCART repository resources accessible from isolated workspaces.
- Stop ignoring root-level `Copy`, `Dynamic`, and `data` so regressions become visible in `git status`.
