### PR TITLE
Refactor callsite identity to structured artifact keys

### DIFF
--- a/API/LibApi.py
+++ b/API/LibApi.py
@@ -7,7 +7,7 @@
 
 import copy
 import re
-from Tool.tool import get_parameter
+from Tool.tool import getParameter
 
 
 
@@ -113,7 +113,7 @@ class APIOBJ:
             pString=objP.findall(item) #获取函数参数
             api.parameters_string=''.join(pString) #保存参数整体的字符串
             if len(pString)>0:
-                lst=get_parameter(pString[0]) #拆分参数
+                lst=getParameter(pString[0]) #拆分参数
                 #把self和cls去掉
                 if 'self' in lst:
                     lst.remove('self')

--- a/Change/changeAnalyze.py
+++ b/Change/changeAnalyze.py
@@ -10,7 +10,7 @@ import re
 import copy
 import subprocess
 from API.LibApi import Parameter 
-from Tool.tool import get_parameter,removeParameter,getFileName,resolvePythonExecutable
+from Tool.tool import getParameter,removeParameter,getFileName,resolvePythonExecutable
 
 
 
@@ -106,7 +106,7 @@ def updateErrorLst(errorLog,errorLst):
 #  @return ansDict The query result 
 def querySharedDict(callAPI,sharedDict):
     ansDict={}
-    k=removeParameter(callAPI)
+    k=callAPI
     if k in sharedDict:
         ansDict['current']=sharedDict[k]['current']
         ansDict['target']=sharedDict[k]['target']
@@ -122,7 +122,7 @@ def querySharedDict(callAPI,sharedDict):
 #  @param targetDict The API signature of the target version
 #  @param sharedDict The API mapping dictionary: multiprocessing.manager.dict()
 def updateSharedDict(callAPI,currentDict,targetDict,sharedDict):
-    key=removeParameter(callAPI)
+    key=callAPI
     if key not in sharedDict: #没有就添加
         sharedDict[key]={}
         innerDict=sharedDict[key]
@@ -173,11 +173,11 @@ def isDifferType(oldType,newType):
         if 'Union' in oldType:
             pattern=r'.*?Union\[(.*)\].*?'
             result=re.findall(pattern,oldType)
-            oldLst=get_parameter(result[0])
+            oldLst=getParameter(result[0])
         elif 'Optional' in oldType:
             pattern=r'.*?Optional\[(.*)\].*?'
             result=re.findall(pattern,oldType)
-            oldLst=get_parameter(result[0])
+            oldLst=getParameter(result[0])
         elif '|' in oldType:
             oldLst=oldType.split('|')
         else: #当oldType就是一个具体的类型而不是集合时，比如int
@@ -191,11 +191,11 @@ def isDifferType(oldType,newType):
         if 'Union' in newType:
             pattern=r'.*?Union\[(.*)\].*?'
             result=re.findall(pattern,newType)
-            newLst=get_parameter(result[0])
+            newLst=getParameter(result[0])
         elif 'Optional' in newType:
             pattern=r'.*?Optional\[(.*)\].*?'
             result=re.findall(pattern,newType)
-            newLst=get_parameter(result[0])
+            newLst=getParameter(result[0])
         elif '|' in newType:
             newLst=newType.split('|')
         else:
@@ -227,7 +227,7 @@ def para2Obj(paraStr):
         paraStr=paraStr[1:-1]
     
     if paraStr:
-        lst=get_parameter(paraStr)
+        lst=getParameter(paraStr)
     else:
         lst=[]
     lst=[para for para in lst if para != '/'] # 2026/4/23 当前修复模型只区分args/kwargs，忽略仅位置参数分隔符
@@ -625,10 +625,12 @@ def isCompatible(current,target):
 #  @param currentEnv Virtual environment of the current version
 #  @param targetEnv Virtual environment of the target version
 #  @parami errLst Error message logging list
+#  @param callKey Unique callsite artifact id
 #  @return lst[0] The API call string with added parameter values (load from pkl file) 
-# def addValueForAPI(callAPI,projName,runPath,runCommand,virtualEnv,errLst):
-def addValueForAPI(callAPI,projName,runPath,runCommand,currentEnv,targetEnv,errLst,callKey=None):
-    pklKey = callKey or callAPI
+def addValueForAPI(callAPI,projName,runPath,runCommand,currentEnv,targetEnv,errLst,callKey):
+    if not callKey:
+        raise ValueError('callKey is required for API value artifacts')
+    pklKey = callKey
     pklName=getFileName(pklKey,'.pkl')
     flag=0
     # 参数补值沿用动态匹配的候选顺序，并优先使用目标环境重新生成的pkl

--- a/Extract/extractCall.py
+++ b/Extract/extractCall.py
@@ -42,8 +42,8 @@ class Import(ast.NodeVisitor):
 ## Extract all call type nodes from a project source file
 ## 抽取项目源码中的所有call类型节点
 #
-#  Use DFS algorithm to traverse the call type node from the root node. Each API call is stored in a tuple (API name, parameters, call statement, line no) 
-#  从根节点开始，直接找根节点的孩子，Call存在于Expr和Assign节点中。每个API调用存储为四元组(API名称,参数,调用语句,行号)
+#  Use DFS algorithm to traverse the call type node from the root node. Each API call is stored in a tuple (API name, parameters, call statement, line/column span)
+#  从根节点开始，直接找根节点的孩子，Call存在于Expr和Assign节点中。每个API调用存储调用语句及其行列位置
 class GetFuncCall:
     def __init__(self):
         self._func_call=[] #list中每个元素都是一个tuple
@@ -68,9 +68,18 @@ class GetFuncCall:
             for keyword in node.keywords:
                 argLst.append(ast.unparse(keyword))
             parameters=','.join(argLst)
-            if (callName,parameters,callState,node.lineno) not in self._func_call:
+            callInfo=(
+                callName,
+                parameters,
+                callState,
+                node.lineno,
+                node.col_offset,
+                getattr(node,'end_lineno',None),
+                getattr(node,'end_col_offset',None),
+            )
+            if callInfo not in self._func_call:
                 # print(node.lineno,'<-->',callState)
-                self._func_call.append((callName,parameters,callState,node.lineno)) #四元组：callAPI名，callAPI参数，...
+                self._func_call.append(callInfo)
             else:
                 pass
                 # print(node.lineno,'<-->',callState)

--- a/Extract/getCall.py
+++ b/Extract/getCall.py
@@ -7,6 +7,7 @@
 
 import ast
 from Extract.extractCall import *
+from Tool.callsite import makeCallsiteRecord
 
 
 
@@ -190,9 +191,10 @@ def modifyWithName(callName, withitemCallName, lineno=None):
 #
 #  @param filePath The .py file path
 #  @param libName The target lib name (e.g., torch) 
-#  @return A dictionary, where the key is the restored API call path + parameters, the value is the original API call + parameters 
-#  @return 返回值是一个字典，key是还原后的API+参数，value是还原前的API+参数
-def getCallFunction(filePath,libName):
+#  @param projPath The project root path
+#  @return Callsite record dictionaries keyed by artifact id
+#  @return 返回以运行产物id为key的调用点记录字典
+def getCallFunction(filePath,libName,projPath=None):
     with open(filePath,'r',encoding='UTF-8') as f:
         codeText=f.read()
         f.seek(0)
@@ -215,16 +217,16 @@ def getCallFunction(filePath,libName):
         # 找出树中所有的Call节点
         call_visitor=GetFuncCall()
         call_visitor.dfsVisit(root_node)
-        all_func_calls=call_visitor.func_call #[(api1,para1,callState, lineno),(api2,para2, callState, lineno),...()]
+        all_func_calls=call_visitor.func_call #[(api1,para1,callState, lineno,col,...),(api2,para2, callState, lineno,col,...),...()]
         
         # 通过赋值语句和import字典来还原每个调用的API
         apiFormatDict={} #保存还原前的API后还原后的API的对应关系
         selfAPIs=[] #保存通过self调用的API
-        for callName,paraStr,callState,lineno in all_func_calls:
+        for callName,paraStr,callState,lineno,colOffset,endLineNo,endColOffset in all_func_calls:
             #print(f"{callName}({paraStr})")
             name_parts=callName.split('.') #按.进行字段拆分
             if 'self' in name_parts[0]:
-                selfAPIs.append((callName,paraStr,callState,lineno))
+                selfAPIs.append((callName,paraStr,callState,lineno,colOffset,endLineNo,endColOffset))
             #     # continue
             
             # #先通过赋值语句进行还原
@@ -297,31 +299,43 @@ def getCallFunction(filePath,libName):
             
 
             #函数名和参数分开放，key和value都是tuple
-            apiFormatDict[(secondModify,paraStr,callState,lineno)]=(callName,paraStr,callState,lineno)
+            apiFormatDict[(secondModify,paraStr,callState,lineno,colOffset,endLineNo,endColOffset)]=(callName,paraStr,callState,lineno,colOffset,endLineNo,endColOffset)
         
         # 对self调用的API进行还原
         if len(selfAPIs)>0:
             selfInfo=getSelfAPI(root_node,md_names,libName)
             if len(selfInfo)>0: 
-                for callName,paraStr,callState,lineno in selfAPIs:
+                for callName,paraStr,callState,lineno,colOffset,endLineNo,endColOffset in selfAPIs:
                     name_parts=callName.split('.')
                     for bases,defLst,callLst in selfInfo:
                         if callName in callLst and name_parts[-1] not in defLst:
                             name=bases[0]+'.'+'.'.join(name_parts[1:])
-                            apiFormatDict[(name,paraStr,callState,lineno)]=(callName,paraStr,callState,lineno)
+                            apiFormatDict[(name,paraStr,callState,lineno,colOffset,endLineNo,endColOffset)]=(callName,paraStr,callState,lineno,colOffset,endLineNo,endColOffset)
 
         #把和指定第三方库相关的callAPI都筛选出来
-        callDict={} #此字典用于之后的匹配和变更分析
-        callDict2={} #此字典用于预处理插桩
+        callsiteRecords={}
+        callsiteParamRecords={}
         for key,value in apiFormatDict.items(): #key是还原后的API，value是还原前的API
             if key[0].split('.')[0]==libName:
-                callDict[f"{value[2]}#_{value[3]}"]=f"{key[0]}({key[1]})" #2023.10.23，确保预处理插桩和在目标版本插桩字典的键都是一样的
-                callDict2[f"{value[2]}#_{value[3]}"]=value[1]
+                formatAPI=f"{key[0]}({key[1]})"
+                record=makeCallsiteRecord(
+                    filePath,
+                    value[2],
+                    formatAPI,
+                    value[1],
+                    value[3],
+                    value[4],
+                    value[5],
+                    value[6],
+                    projPath,
+                )
+                callsiteRecords[record['id']]=record
+                callsiteParamRecords[record['id']]=record
 
         #按API的行号从小到大排序,便于之后的插桩 
-        sortedCallDict=dict(sorted(callDict.items(),key=lambda x:int(x[0].split('#_')[-1])))
-        sortedCallDict2=dict(sorted(callDict2.items(),key=lambda x:int(x[0].split('#_')[-1])))
-        return sortedCallDict,sortedCallDict2 
+        sortedCallsiteRecords=dict(sorted(callsiteRecords.items(),key=lambda x:(x[1]['lineno'],x[1]['col_offset'])))
+        sortedCallsiteParamRecords=dict(sorted(callsiteParamRecords.items(),key=lambda x:(x[1]['lineno'],x[1]['col_offset'])))
+        return sortedCallsiteRecords,sortedCallsiteParamRecords 
     
     except SyntaxError as e:
         print(f"when extract invoked API, parsed {filePath} failed: {e}")

--- a/Map/map.py
+++ b/Map/map.py
@@ -11,7 +11,7 @@ import shutil
 import subprocess
 from Map.fuzzyMatch import *
 from Load.loadData import loadLib
-from Tool.tool import removeParameter,getFileName,resolvePythonExecutable,buildRunCommand
+from Tool.tool import removeParameter,getFileName,resolvePythonExecutable,buildRunCommand,getArtifactHash,getArtifactDisplayName
 from Extract.getCall import getCallFunction
 from Preprocess.preprocess import addDictSingle
 
@@ -98,6 +98,9 @@ def saveDynamicMatchSnapshot(pklKey,version,curr,dynamicMatchDict,pklFile=None):
         'phase': phase,
         'version': str(version),
         'callKey': pklKey,
+        'artifact': pklKey,
+        'artifactHash': getArtifactHash(pklKey),
+        'debugName': getArtifactDisplayName(pklKey),
     }
     if pklFile is not None:
         snapshotDict['_pcart']['pklFile']=pklFile
@@ -143,11 +146,14 @@ def hasSaveFailedManifest(pklKey):
 #  @param lock The lock flag 
 #  @param errLst Error list
 #  @param curr=1 Current version flag
+#  @param callKey Unique callsite artifact id
 #  @return dynamicMatchDict Mapped API signatures 
-def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv,lock,errLst,curr=1,callKey=None):
+def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv,lock,errLst,curr=1,*,callKey):
     # pythonPath=f"{virtualEnv}/bin/python" #先指定python解释器的路径
     pythonPath = resolvePythonExecutable(virtualEnv)
-    pklKey = callKey or callAPI
+    if not callKey:
+        raise ValueError('callKey is required for dynamic match artifacts')
+    pklKey = callKey
     pklFile=getFileName(pklKey,'.pkl')
     # withitem调用优先尝试运行时对象，其次尝试还原表达式，最后兼容旧版单pkl
     pklCandidateFiles=[pklFile[:-4]+'__object.pkl',pklFile[:-4]+'__expr.pkl',pklFile]
@@ -321,9 +327,12 @@ def dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv
 #  @param lock The lock flag 
 #  @param errLst Error list
 #  @param curr=1 Current version flag
+#  @param callKey Unique callsite artifact id
 #  @return ans Mapped API signatures 
-def mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,version,virtualEnv,lock,errLst,curr=1,callKey=None):
-    dynamicMatchDict=dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv,lock,errLst,curr,callKey)
+def mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,version,virtualEnv,lock,errLst,curr=1,*,callKey):
+    if not callKey:
+        raise ValueError('callKey is required for API mapping artifacts')
+    dynamicMatchDict=dynamicMatch(callAPI,runCommand,runPath,projName,copyFile,version,virtualEnv,lock,errLst,curr,callKey=callKey)
     ans={}
     ans['format']=formatAPI
     if dynamicMatchDict!=False: #若动态匹配成功,还要对动态匹配的结果进行检查

--- a/Preprocess/preprocess.py
+++ b/Preprocess/preprocess.py
@@ -11,7 +11,7 @@ import shutil
 from Path.getPath import *
 from Extract.getCall import getCallFunction, modifyWithName
 from Extract.extractCall import WithVisitor
-from Tool.tool import getAst,get_parameter,getLastAPIParameter,departAPI,departAPI2,ConditionalReturnTransformer, getFileName, getRunFile
+from Tool.tool import getAst,getParameter,getLastAPIParameter,departAPI,departAPI2,ConditionalReturnTransformer, getFileName, getRunFile
 
 
 
@@ -172,7 +172,7 @@ def convertLocalVar(filePath,libName):
         #step2:判断列表推导式中是否含有第三方库调用的API
         flag=0
         _,callDict=getCallFunction(filePath,libName)
-        callLst=[callAPI.split('#_')[0] for callAPI in callDict.keys()]
+        callLst=[record['call_text'] for record in callDict.values()]
         flag=0
         for node in ast.walk(root):
             if isinstance(node, ast.Call):
@@ -402,17 +402,20 @@ def extractDecorator(root):
 #
 #  @param callAPI The API call
 #  @param filePath The source file path
-def addDictSingle(callAPI,filePath,callKey=None):
+#  @param callKey Unique callsite artifact id
+def addDictSingle(callAPI,filePath,callKey):
+    if not callKey:
+        raise ValueError('callKey is required for API value instrumentation')
     with open(filePath,'r',encoding='UTF-8') as fr:
         codeLst=fr.readlines()
     source=''.join(codeLst)
     
     lineno=getImportLine(codeLst)
-    importDict='from recordValue import paraValueDict\n'
+    importDict='from recordValue import paraValueDict\nfrom recordValue import callsiteInfoDict\n'
     codeLst.insert(lineno,importDict)
     
     paraStr=getLastAPIParameter(callAPI) #获取最后一个API的参数
-    parameterLst=get_parameter(paraStr,space=0) #项目参数不去空格
+    parameterLst=getParameter(paraStr,space=0) #项目参数不去空格
     root=getAst(filePath)
     targetLst=findAssignCall(root)
 
@@ -434,7 +437,12 @@ def addDictSingle(callAPI,filePath,callKey=None):
                     firstPart+=it+'.'
             firstPart=firstPart.rstrip('.')
             
-            key=(callKey or callAPI).replace('"','\\"')
+            key=callKey.replace('"','\\"')
+            callsiteInfo={
+                'call_text': callAPI,
+                'format_api': callAPI,
+            }
+            dicString0=f'callsiteInfoDict[{repr(callKey)}]={repr(callsiteInfo)}\n'
             if firstPart and (firstPart.split('.')[0] in targetLst or firstPart.split('.')[0]=='self') and len(l)==1:
                 lineNo = i + 1
                 receiverExpr=None
@@ -472,6 +480,7 @@ def addDictSingle(callAPI,filePath,callKey=None):
             dicString2=dicString2.rstrip(',')+']\n'
             
             while spaceNum>0:
+                dicString0=' '+dicString0
                 if dicString1:
                     dicString1=' '+dicString1
                 dicString2=' '+dicString2
@@ -486,14 +495,17 @@ def addDictSingle(callAPI,filePath,callKey=None):
                 codeLst.insert(i,dicString2)
                 if dicString1:
                     codeLst.insert(i,dicString1)
+                codeLst.insert(i,dicString0)
             else:
                 if dicString1:
                     dicString1=dicString1.lstrip(' ')#去掉之前添加的空格，重新计算开头的空格数
+                dicString0=dicString0.lstrip(' ')
                 dicString2=dicString2.lstrip(' ') 
                 for j in range(i+1,len(codeLst)):
                     if codeLst[j]!='\n' and '#' not in codeLst[j]:
                         spaceNum=countSpace(codeLst[j])
                         while spaceNum>0:
+                            dicString0=' '+dicString0
                             if dicString1:
                                 dicString1=' '+dicString1
                             dicString2=' '+dicString2
@@ -502,6 +514,7 @@ def addDictSingle(callAPI,filePath,callKey=None):
                         codeLst.insert(j,dicString2)
                         if dicString1:
                             codeLst.insert(j,dicString1)
+                        codeLst.insert(j,dicString0)
                         break
 
             break
@@ -540,13 +553,12 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
     # fileName=filePath.split('/')[-1][0:-3]
     fileName = os.path.basename(filePath)[0:-3]
     fileRelativePath=filePath.split(f'{projName}',1)[-1]
-    coverageKey = fileRelativePath.replace('\\', '/').lstrip('/').rsplit('.', 1)[0]
     fileAbsolutePath=projPath+fileRelativePath
     
     lineno=getImportLine(codeLst)
-    importDict='from recordValue import paraValueDict\nfrom recordValue import apiCoveredSet\n'
+    importDict='from recordValue import paraValueDict\nfrom recordValue import apiCoveredSet\nfrom recordValue import callsiteInfoDict\n'
     codeLst.insert(lineno,importDict)
-    _,callDict=getCallFunction(fileAbsolutePath,libName)
+    _,callDict=getCallFunction(fileAbsolutePath,libName,projPath)
 
     targetLst=findAssignCall(root) #用来区分调用者是否来自赋值语句，比如a.f(), tf.f(), or self.f()
  
@@ -563,10 +575,11 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
     preInsertAPI='' #记录上一个插桩的API是哪个
     preInsertAPICount=0 #记录上一个插桩行中出现了几次被插的API
     decoratorLine = list() #记录装饰器出现的行号 -- 2025.5.12
-    for callState,paraStr in callDict.items(): #key是api调用表达式，value是list,保存所有参数
+    for artifactId,record in callDict.items(): #key是调用点artifact id，value是结构化调用点记录
         flag=0 #标记API是否找到了插桩的位置
-        lineno=int(callState.split('#_')[-1]) #这个lineno是原项目中的行数
-        callState=callState.split('#_')[0]
+        lineno=int(record['lineno']) #这个lineno是原项目中的行数
+        callState=record['call_text']
+        paraStr=record['parameters']
         callAPI=callState.replace(' ','')
         if callAPI==preInsertAPI: #判断当前要处理的API与上一个API是否相同
             preInsertAPICount-=1
@@ -585,10 +598,18 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
                     preInsertAPI=callAPI
                 flag=1
                 spaceNum=countSpace(codeLst[i])
-                #key=callState.replace('"','\\"') #把字符串中的"改成\"
-                key=getFileName(callState,'') # 2025/5/25 Fix inconsistency between callAPI name and the key name 
-                key=key.replace('"','\\"') #把字符串中的"改成\"
-                callSiteKey=f'{key}#_{lineno}'
+                callSiteKey=artifactId
+                callsiteInfo={
+                    'artifact_hash': record.get('artifact_hash',''),
+                    'rel_path': record.get('rel_path',''),
+                    'lineno': record.get('lineno'),
+                    'col_offset': record.get('col_offset'),
+                    'end_lineno': record.get('end_lineno'),
+                    'end_col_offset': record.get('end_col_offset'),
+                    'call_text': record.get('call_text',''),
+                    'format_api': record.get('format_api',''),
+                }
+                dicString0=f'callsiteInfoDict[{repr(callSiteKey)}]={repr(callsiteInfo)}\n'
                 l=departAPI(callState)
                 l2=departAPI2(callState)
                 firstPart=''
@@ -627,7 +648,7 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
                     dicString1=f'paraValueDict[\"@{callSiteKey}\"]={{}}; paraValueDict[\"@{callSiteKey}\"][\"object\"]={firstPart}; paraValueDict[\"@{callSiteKey}\"][\"expr\"]=\"{initialCallName}\"\n'
                 #再保存API的参数值
                 dicString2=f'paraValueDict[\"{callSiteKey}\"]=['
-                paraLst=get_parameter(paraStr,space=0) #项目参数不去空格2023-12-14
+                paraLst=getParameter(paraStr,space=0) #项目参数不去空格2023-12-14
                 for para in paraLst: 
                     if '=' in para and "'='" not in para and '"="' not in para: #若参数的形式为key=f(x=1),只要确保=的前面不含括号即可
                         pos=para.find('=') #找到第一个=的位置,存在x=(a==b)和a==b形式
@@ -638,9 +659,9 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
                     dicString2=dicString2+para+','
                 dicString2=dicString2.rstrip(',')+']\n'
                 
-                dicString3=f'apiCoveredSet.add(\"{coverageKey}##{lineno}##{key}\")\n'
-                # print(f"{coverageKey}##{lineno}##{key}")
+                dicString3=f'apiCoveredSet.add(\"{callSiteKey}\")\n'
                 while spaceNum>0:
+                    dicString0=' '+dicString0
                     if dicString1:
                         dicString1=' '+dicString1
                     dicString2=' '+dicString2
@@ -659,20 +680,23 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
                     codeLst.insert(i,dicString2)
                     if dicString1:
                         codeLst.insert(i,dicString1)
+                    codeLst.insert(i,dicString0)
                     #记录当前插在了哪一行
                     if dicString1:
-                        insertStartLine=i+3
+                        insertStartLine=i+4
                     else:
-                        insertStartLine=i+2
+                        insertStartLine=i+3
                 else:
                     if dicString1:
                         dicString1=dicString1.lstrip(' ') #去掉之前添加的空格，重新计算开头的空格数
+                    dicString0=dicString0.lstrip(' ')
                     dicString2=dicString2.lstrip(' ') 
                     dicString3=dicString3.lstrip(' ') 
                     for j in range(i+1,len(codeLst)):
                         if codeLst[j]!='\n' and '#' not in codeLst[j]:
                             spaceNum=countSpace(codeLst[j])
                             while spaceNum>0:
+                                dicString0=' '+dicString0
                                 if dicString1:
                                     dicString1=' '+dicString1
                                 dicString2=' '+dicString2
@@ -682,11 +706,12 @@ def addDictAll(projPath,projName,filePath,runFileLst,libName,runPath,runCommand)
                             codeLst.insert(j,dicString2)
                             if dicString1:
                                 codeLst.insert(j,dicString1)
+                            codeLst.insert(j,dicString0)
                             #记录当前插在了哪一行
                             if dicString1:
-                                insertStartLine=j+3
+                                insertStartLine=j+4
                             else:
-                                insertStartLine=j+2
+                                insertStartLine=j+3
                             break
   
                 break
@@ -849,7 +874,7 @@ def saveStructure(projPath,libName):
     filePath=[it for it in pathObj.path if it.endswith('py')]
     for file in filePath:
         _,callDict=getCallFunction(file,libName)
-        callLst=[callAPI.split('#_')[0] for callAPI in callDict.keys()] #去掉API中的行号信息
+        callLst=[record['call_text'] for record in callDict.values()]
         # with open(file,'r') as fr:
         with open(file, 'r', encoding='UTF-8') as fr:
             code=fr.read()

--- a/Repair/repair.py
+++ b/Repair/repair.py
@@ -8,7 +8,7 @@
 import os
 import ast
 import subprocess
-from Tool.tool import getAst,getFileName,get_parameter,getLastAPIParameter,resolvePythonExecutable
+from Tool.tool import getAst,getFileName,getParameter,getLastAPIParameter,resolvePythonExecutable
 from API.LibApi import Parameter
 from Change.changeAnalyze import para2Obj
 
@@ -77,7 +77,7 @@ def mirrorAPI(fixedAPI,dic):
     paraObjLst=[] #保存参数对象
     paraStr=paraStr.replace(' ','') #去空格
     if paraStr:
-        lst=get_parameter(paraStr,space=0)
+        lst=getParameter(paraStr,space=0)
     else:
         lst=[]
     for i in range(len(lst)):
@@ -264,11 +264,14 @@ def fix(callAPI,repairDict,node,starFlag,twoStarFlag):
 #  @param virtualEnv The virtual environment of the target lib version
 #  @param runPath The relative path of the run file
 #  @param runCommand The run command of the project
+#  @param callKey Unique callsite artifact id
 #  @return result Dynamic validation result
-def validateByRun(callAPI,apiWithValue,projName,virtualEnv,runPath,runCommand,callKey=None):
+def validateByRun(callAPI,apiWithValue,projName,virtualEnv,runPath,runCommand,callKey):
     if apiWithValue=='':
         return None
-    pklName=getFileName(callKey or callAPI,'.pkl')
+    if not callKey:
+        raise ValueError('callKey is required for validation artifacts')
+    pklName=getFileName(callKey,'.pkl')
     # 验证阶段复用候选pkl顺序，保证修复验证和动态匹配读取的是同一类接收者
     pklCandidates=[
         'new_'+pklName[:-4]+'__object.pkl',
@@ -368,8 +371,9 @@ def validateByStr(fixedAPI,repairDict,targetAPIDefinition,starFlag,twoStarFlag):
 #  @param repairLst  List of repair operation dictionary
 #  @param virtualEnv The virtual environment of the target lib version
 #  @param errLst List of error messages
+#  @param callKey Unique callsite artifact id
 #  @return repairResults 
-def repairTask(root,callAPI,apiWithValue,projName,runPath,runCommand,repairLst,virtualEnv,errLst,callKey=None):
+def repairTask(root,callAPI,apiWithValue,projName,runPath,runCommand,repairLst,virtualEnv,errLst,callKey):
     #静态修复,pkl加载失败，只能进入静态修复
     repairCandidates=[]
     if apiWithValue=='':
@@ -457,103 +461,3 @@ def repairTask(root,callAPI,apiWithValue,projName,runPath,runCommand,repairLst,v
             return repairCandidates[0],'Incompatible',fixFlag
     else:
         return str(repairCandidates),'Unknown','Unknown'
-
-        
-# def repairTask(root,callAPI,apiWithValue,projName,runPath,runCommand,repairLst,virtualEnv,errLst):
-#     #静态修复,pkl加载失败，只能进入静态修复
-#     repairCandidates=[]
-#     if apiWithValue=='':
-#         for repairDict,targetPara in repairLst:
-#             starFlag=0 #判断目标版本的参数定义中是否含有*args
-#             twoStarFlag=0 #判断目标版本的参数定义中是否含有*kwargs
-#             if '*args' in targetPara:
-#                 starFlag=1
-#             if '**' in targetPara:
-#                 twoStarFlag=1
-#             apiRoot=getAst(callAPI,1)
-#             fix(callAPI,repairDict,apiRoot,starFlag,twoStarFlag)
-#             fixedAPI=ast.unparse(apiRoot)
-#             if validateByStr(fixedAPI,repairDict,targetPara,starFlag,twoStarFlag):
-#                 if fixedAPI not in repairCandidates:
-#                     repairCandidates.append((fixedAPI,repairDict))
-        
-#         if len(repairCandidates)==0:
-#             return str(repairCandidates), 'Unknown', 'Unknown'
-        
-#         elif len(repairCandidates)==1:
-#             fixedAPI=repairCandidates[0][0]
-#             repairDict=repairCandidates[0][1]
-#             fix(callAPI,repairDict,root,starFlag,twoStarFlag)
-#             if callAPI.replace(' ','').replace('"','').replace("'",'')==fixedAPI.replace(' ','').replace('"','').replace("'",''):
-#                 return fixedAPI,"Compatible","Unknown"
-#             else:
-#                 return fixedAPI,"Incompatible","Unknown"
-        
-#         else:
-#             tempLst=[x[0] for x in repairCandidates]
-#             return str(tempLst),"Unknown", "Unknown"
-
-
-#     #pkl加载成功，但匹配的结果也可能是多个，内置API只能静态匹配
-#     failedLst=[]
-#     for repairDict,targetPara in repairLst:
-#         starFlag=0 #判断目标版本的参数定义中是否含有*args
-#         twoStarFlag=0 #判断目标版本的参数定义中是否含有*kwargs
-#         # 1.先进行静态验证
-#         if '*args' in targetPara:
-#             starFlag=1
-#         if '**' in targetPara:
-#             twoStarFlag=1
-#         apiRoot=getAst(callAPI,1)
-#         fix(callAPI,repairDict,apiRoot,starFlag,twoStarFlag)
-#         fixedAPI=ast.unparse(apiRoot)
-#         if not validateByStr(fixedAPI,repairDict,targetPara,starFlag,twoStarFlag):
-#             continue
-#         elif len(repairLst)==1:
-#             repairCandidates.append((fixedAPI,repairDict))
-
-#         #2. 动态验证
-#         fixFlag='Failed'
-#         apiRoot=getAst(apiWithValue,1)
-#         fix(apiWithValue,repairDict,apiRoot,starFlag,twoStarFlag)
-#         apiWithValueFixed=ast.unparse(apiRoot)
-#         #1先通过动态运行,判断其是否修复成功
-#         result=validateByRun(callAPI,apiWithValueFixed,projName,virtualEnv,runPath,runCommand)
-#         # print(result.stdout,result.stderr)
-#         if result==None:
-#             if (fixedAPI,repairDict) not in repairCandidates:
-#                 repairCandidates.append((fixedAPI,repairDict))
-#             fixFlag='Unknown'
-        
-#         elif result.returncode!=0:
-#             errLst.append(f"{callAPI}, validate error: {result.stderr}\n")
-#             failedLst.append(f"{callAPI}, validate error: {result.stderr}\n")
-#             if 'dill' in result.stderr:
-#                 fixFlag='Unknown'
-#                 if (fixedAPI,repairDict) not in repairCandidates:
-#                     repairCandidates.append((fixedAPI,repairDict))
-#         else:
-#             fixFlag='Successful'
-#             # for k,v in repairDict.items():
-#             #     print(k,v)
-#             # print('\n')
-#             # print(callAPI)
-#             # print(fixedAPI)
-#             if (fixedAPI,repairDict) not in repairCandidates:
-#                 repairCandidates.append((fixedAPI,repairDict))
-#             break
-     
-#     # repairCandidates=list(set(repairCandidates)) 
-#     if len(repairCandidates)==0:
-#         return str(repairCandidates), 'Unknown' , 'Unknown'
-#     elif len(repairCandidates)==1:
-#         fixedAPI=repairCandidates[0][0]
-#         repairDict=repairCandidates[0][1]
-#         fix(callAPI,repairDict,root,starFlag,twoStarFlag)
-#         if callAPI.replace(' ','').replace('"','').replace("'",'')==fixedAPI.replace(' ','').replace('"','').replace("'",''):
-#             return fixedAPI,'Compatible',fixFlag
-#         else:
-#             return fixedAPI,'Incompatible',fixFlag
-#     else:
-#         tempLst=[x[0] for x in repairCandidates]
-#         return str(tempLst),'Unknown','Unknown'

--- a/Script/addValueForAPI.py
+++ b/Script/addValueForAPI.py
@@ -7,10 +7,14 @@
 
 import sys
 import dill
-from codeUtils import getFileName, removeParameter, departAPI, departAPI2, get_parameter, getLastAPIParameter
+from codeUtils import removeParameter, departAPI2, getParameter, getLastAPIParameter
 
 
 #首先加载PKL
+if len(sys.argv)<4:
+    print('lookupKey is required',file=sys.stderr)
+    sys.exit(2)
+
 pklPath=sys.argv[1]
 with open(pklPath,'rb') as fr:
     paraValueDict=dill.load(fr)
@@ -18,16 +22,13 @@ print("load pkl successfully")
 
 
 callAPI=sys.argv[2]
-lookupKey=sys.argv[3] if len(sys.argv)>3 else callAPI
-lst1=departAPI(callAPI) #将API按点进行拆分a.b(y).c(z)拆分成a.b(y), a.b(y).c(z)
+lookupKey=sys.argv[3]
 lst2=departAPI2(callAPI) #拆分成a(x), b(y), c(z)
-tempLst=[]
-cnt=0
 s=''
 #给API填上参数的具体值
 for key in paraValueDict.keys():
     #if callAPI.replace(' ','')==key.replace(' ',''):
-    if getFileName(lookupKey,'')==getFileName(key,''): # 2025/5/25 Fix inconsistency between callAPI name and the key name
+    if lookupKey==key:
         # 2025/5/25 将复杂API参数键替换为简单键，例如复杂的引号符号
         newKey = "callKey"  
         if newKey not in paraValueDict:
@@ -35,7 +36,7 @@ for key in paraValueDict.keys():
 
         lastAPI=lst2[-1]
         paraStr=getLastAPIParameter(lastAPI)
-        paraLst=get_parameter(paraStr,space=0)
+        paraLst=getParameter(paraStr,space=0)
         s=removeParameter(lastAPI,1)+'('
 
         #先把API的参数值填上
@@ -58,13 +59,6 @@ for key in paraValueDict.keys():
         firstPart=lst2[0]    
         if k in paraValueDict:
             receiver = paraValueDict.get(k)
-            # 新版withitem pkl可能保存object/expr候选；旧版pkl仍是单个接收者
-            if isinstance(receiver, dict):
-                if 'object' in receiver:
-                    receiver = receiver['object']
-                elif 'expr' in receiver:
-                    receiver = receiver['expr']
-                paraValueDict[k] = receiver
             # 2025/5/25 将复杂API参数键替换为简单键，例如复杂的引号符号
             newK = '@' + newKey 
             if newK not in paraValueDict:

--- a/Script/codeUtils.py
+++ b/Script/codeUtils.py
@@ -6,10 +6,65 @@
 ## Used by Preprocess/preprocess.py, dynamicMatch.py, addValueForAPI.py
 
 import hashlib
+import re
+
+
+ARTIFACT_HASH_PATTERN=re.compile(r'(?:^|__)([0-9a-f]{64})$')
+
+
+## Return artifact hash from an artifact id
+## 从运行产物id中提取hash
+#
+#  @param artifactId The artifact id
+#  @return artifact hash or empty string
+def getArtifactHash(artifactId):
+    match=ARTIFACT_HASH_PATTERN.search(artifactId)
+    if match:
+        return match.group(1)
+    return ''
+
+
+## Return readable artifact display name
+## 返回可读运行产物展示名
+#
+#  @param artifactId The artifact id
+#  @return display name
+def getArtifactDisplayName(artifactId):
+    artifactHash=getArtifactHash(artifactId)
+    if artifactHash and artifactId.endswith(artifactHash):
+        displayName=artifactId[:-len(artifactHash)].rstrip('_')
+        return displayName or artifactHash
+    return artifactId
+
+
+## Shorten artifact file name while preserving full hash
+## 缩短运行产物文件名并保留完整hash
+#
+#  @param fileName The artifact file stem
+#  @param extension The extension of the file
+#  @return fileName The shortened file name
+def shortenArtifactFileName(fileName,extension):
+    fileName=re.sub(r'[^0-9A-Za-z_.-]+','_',fileName).strip('._')
+    length=255-len(extension) if extension else 255
+    if len(fileName)<=length:
+        return fileName+extension
+    artifactHash=getArtifactHash(fileName)
+    if not artifactHash:
+        return fileName[:length]+extension
+    suffix='__'+artifactHash
+    prefixLength=max(0,length-len(suffix))
+    prefix=fileName[:prefixLength].rstrip('_')
+    return prefix+suffix+extension
 
 ## Normalize file name
 ## 给文件取名字
+#
+#  @param fileName Typically, the API call string or callsite artifact id is input as the file name
+#  @param extension The extension of the file
+#  @return fileName The normalized file name
 def getFileName(fileName,extension):
+    if getArtifactHash(fileName):
+        return shortenArtifactFileName(fileName,extension)
     #step1:先把fileName中的非法字符去除
     fileName=fileName.replace(' ','')
     fileName=fileName.replace('/','')
@@ -21,7 +76,6 @@ def getFileName(fileName,extension):
 
     fileName+=extension 
     return fileName
-
 
 #去掉API中的参数部分
 def removeParameter(s,flag=0): 
@@ -151,11 +205,18 @@ def departAPI2(s,separator='.'):
     return ansLst
 
 
-#将参数字符串拆分成单个的参数
-#apiName(x,y=1,z:int,w=(p1,p2={1,(1m,23)}),device: Union[Device, int] = None, abbreviated: bool ={'a','b'}) -> str
-#默认按逗号进行拆分,也可按'.'进行拆分，比如a.b.c
+## Split parameter string into list of separated parameters
+## 将参数字符串拆分成单个的参数
+#
+#  apiName(x,y="<bold>Hello, World!</bold>",z:int,w=(p1,p2={1,(1m,23)}),device: Union[Device, int] = None, abbreviated: bool ={'a','b'}) -> str
+#  默认按逗号进行拆分,也可按'.'进行拆分，比如a.b.c
+#  拆分参数的时候没有考虑到x="hello,wolrd"带冒号的情况，会错误拆成两个
+#
+#  @param p_string Parameter string
+#  @param separator The separator, ',' is the default value
 #  @param space Determine whether to remove the space in the parameter string 
-def get_parameter(p_string,separator=',',space=1):
+#  @return parameters List of separater parameters
+def getParameter(p_string,separator=',',space=1):
     #库定义的参数去空格，项目中的参数不去空格，防止出问题
     if space: #默认是去空格的
         p_string=p_string.replace(' ','') #去掉参数中的空格

--- a/Script/dynamicMatch.py
+++ b/Script/dynamicMatch.py
@@ -9,11 +9,15 @@ import sys
 import json
 import inspect
 import dill
-from codeUtils import getFileName, removeParameter, departAPI, departAPI2
+from codeUtils import getFileName, removeParameter, departAPI2
 
 
 
 #step1: 加载PKL
+if len(sys.argv)<5:
+    print('lookupKey is required',file=sys.stderr)
+    sys.exit(2)
+
 pklPath=sys.argv[1]
 with open(pklPath,'rb') as fr:
     paraValueDict=dill.load(fr)
@@ -24,11 +28,9 @@ print("load pkl successfully")
 #step2: 动态匹配
 callAPI=sys.argv[2]
 jsonPrefix=sys.argv[3]
-lookupKey=sys.argv[4] if len(sys.argv)>4 else callAPI
+lookupKey=sys.argv[4]
 matchDict={}
-tempLst=[]
 s=''
-lst1=departAPI(callAPI) #将API按点进行拆分a(x).b(y).c(z)拆分成a(x), a(x).b(y), a(x).b(y).c(z)
 lst2=departAPI2(callAPI) #拆分成a(x), b(y), c(z)
 
 lastAPI=lst2[-1]
@@ -37,21 +39,13 @@ s=removeParameter(lastAPI,1)
 #给API填上参数的具体值
 for key in paraValueDict.keys():
     #if callAPI.replace(' ','')==key.replace(' ',''):
-    # 2025/5/25 Fix inconsistency between callAPI name and the key name
-    if getFileName(lookupKey,'')==getFileName(key,''): 
+    if lookupKey==key:
         #把函数的上文依赖给填上,比如self.a(x)中的self, a.b(2).c(3)中的a.b(2)
         k='@{}'.format(key)
         firstPart=lst2[0]
         if k in paraValueDict:
             #新增Context Manager对象动态匹配支持 -- 2025/5/20
             receiver = paraValueDict.get(k)
-            # 新版withitem pkl可能保存object/expr候选；旧版pkl仍是单个接收者
-            if isinstance(receiver, dict):
-                if 'object' in receiver:
-                    receiver = receiver['object']
-                elif 'expr' in receiver:
-                    receiver = receiver['expr']
-                paraValueDict[k] = receiver
             if isinstance(receiver,str):
                 s=receiver+'.'+s
             else:

--- a/Script/recordValue.py
+++ b/Script/recordValue.py
@@ -9,7 +9,7 @@ import os
 import atexit
 import dill
 import json
-from codeUtils import getFileName
+from codeUtils import getFileName, getArtifactHash, getArtifactDisplayName
 
 
 PCART_PKL_REL_PATH='__PCART_PKL_REL_PATH__'
@@ -17,6 +17,7 @@ PCART_USE_CALLSITE_NAME=__PCART_USE_CALLSITE_NAME__
 
 paraValueDict={}
 apiCoveredSet=set()
+callsiteInfoDict={}
 
 
 ## Save collected runtime values to pkl files
@@ -29,6 +30,7 @@ def savePkls():
             continue
         k='@{}'.format(key)
         receiver=paraValueDict.get(k)
+        callsiteInfo=callsiteInfoDict.get(key,{})
         candidates=[]
         # Receiver may have two fallback forms: runtime object first, expression second
         # 调用者对象可能有两种回退形式：优先运行时对象，其次还原表达式
@@ -41,6 +43,16 @@ def savePkls():
             candidates.append(('',receiver))
         candidateManifest={
             'callsite': key,
+            'artifact': key,
+            'artifactHash': getArtifactHash(key),
+            'debugName': getArtifactDisplayName(key),
+            'source': callsiteInfo.get('rel_path',''),
+            'line': callsiteInfo.get('lineno'),
+            'column': callsiteInfo.get('col_offset'),
+            'endLine': callsiteInfo.get('end_lineno'),
+            'endColumn': callsiteInfo.get('end_col_offset'),
+            'call': callsiteInfo.get('call_text',''),
+            'format_api': callsiteInfo.get('format_api',''),
             'covered': True,
             'candidates': [],
         }

--- a/Tool/callsite.py
+++ b/Tool/callsite.py
@@ -1,0 +1,196 @@
+## @package callsite
+#  Provide structured callsite identity helpers
+#
+#  More details (TODO)
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+## Callsite identity class
+## 调用点身份类
+#
+#  A CallsiteIdentity describes one AST Call node with project-relative path,
+#  source span and normalized call text.
+#  CallsiteIdentity使用项目相对路径、源码位置和归一化调用文本描述一个AST调用节点。
+@dataclass(frozen=True)
+class CallsiteIdentity:
+    ## The relative path from project root
+    ## 相对于项目根目录的文件路径
+    rel_path: str
+
+    ## The line number of AST Call node
+    ## AST调用节点所在行号
+    lineno: int
+
+    ## The column offset of AST Call node
+    ## AST调用节点所在列偏移
+    col_offset: int
+
+    ## The end line number of AST Call node
+    ## AST调用节点结束行号
+    end_lineno: Optional[int]
+
+    ## The end column offset of AST Call node
+    ## AST调用节点结束列偏移
+    end_col_offset: Optional[int]
+
+    ## The original call text used for report display
+    ## 报告展示用的原始调用文本
+    call_text: str
+
+    ## The normalized call text used for identity generation
+    ## 生成调用点身份用的归一化调用文本
+    normalized_call: str
+
+    ## Return the payload used to generate artifact id
+    ## 返回用于生成运行产物id的数据
+    def artifactPayload(self):
+        return {
+            'rel_path': self.rel_path,
+            'lineno': self.lineno,
+            'col_offset': self.col_offset,
+            'end_lineno': self.end_lineno,
+            'end_col_offset': self.end_col_offset,
+            'normalized_call': self.normalized_call,
+        }
+
+    ## Return stable artifact hash for a callsite
+    ## 返回调用点稳定运行产物hash
+    def artifactHash(self):
+        payload = json.dumps(
+            self.artifactPayload(),
+            sort_keys=True,
+            separators=(',', ':'),
+        ).encode('utf-8')
+        return hashlib.sha256(payload).hexdigest()
+
+    ## Return stable readable artifact id for a callsite
+    ## 返回调用点稳定可读运行产物id
+    def artifactId(self):
+        MAX_REL = 64   # max slug length for relative path
+        MAX_CALL = 48  # max slug length for call name
+        # slugify relative path
+        rel_slug = re.sub(r'[^0-9A-Za-z]+', '_', str(self.rel_path)).strip('_').lower()
+        rel_slug = re.sub(r'_+', '_', rel_slug)[:MAX_REL].strip('_') or 'source'
+        # slugify call name (everything before the first '(')
+        call_name = str(self.normalized_call).split('(', 1)[0]
+        call_slug = re.sub(r'[^0-9A-Za-z]+', '_', call_name).strip('_').lower()
+        call_slug = re.sub(r'_+', '_', call_slug)[:MAX_CALL].strip('_') or 'call'
+        return f'{rel_slug}__L{self.lineno}C{self.col_offset}__{call_slug}__{self.artifactHash()}'
+
+
+## Callsite record class
+## 调用点记录类
+#
+#  A CallsiteRecord separates runtime artifact id, report display text and
+#  static matching API.
+#  CallsiteRecord用于分离运行产物id、报告展示文本和静态匹配API。
+@dataclass(frozen=True)
+class CallsiteRecord:
+    ## The structured callsite identity
+    ## 结构化调用点身份
+    identity: CallsiteIdentity
+
+    ## The stable id used by pkl/json/manifest/sharedDict
+    ## pkl/json/manifest/sharedDict使用的稳定id
+    artifact_id: str
+
+    ## The restored API used for static matching
+    ## 静态匹配用的还原API
+    format_api: str
+
+    ## The original parameter string of the callsite
+    ## 调用点原始参数字符串
+    parameters: str
+
+    ## Convert callsite record to dictionary
+    ## 将调用点记录转换为字典
+    def toDict(self):
+        return {
+            'id': self.artifact_id,
+            'artifact_hash': self.identity.artifactHash(),
+            'rel_path': self.identity.rel_path,
+            'lineno': self.identity.lineno,
+            'col_offset': self.identity.col_offset,
+            'end_lineno': self.identity.end_lineno,
+            'end_col_offset': self.identity.end_col_offset,
+            'call_text': self.identity.call_text,
+            'normalized_call': self.identity.normalized_call,
+            'format_api': self.format_api,
+            'parameters': self.parameters,
+        }
+
+
+## Normalize call text for identity generation
+## 归一化调用文本，用于生成调用点身份
+#
+#  @param call_text The original call text
+#  @return normalized call text
+def normalizeCallText(call_text):
+    return call_text.replace(' ', '').replace('"', '').replace("'", '')
+
+
+## Normalize source file path to project relative path
+## 将源码路径归一化为项目相对路径
+#
+#  @param file_path The source file path
+#  @param proj_path The project root path
+#  @return normalized relative path
+def normalizeRelPath(file_path, proj_path=None):
+    normalized_file = os.path.abspath(file_path).replace('\\', '/')
+    if proj_path:
+        normalized_root = os.path.abspath(proj_path).replace('\\', '/').rstrip('/')
+        try:
+            rel_path = os.path.relpath(normalized_file, normalized_root).replace('\\', '/')
+            if not rel_path.startswith('..'):
+                return rel_path
+        except ValueError:
+            pass
+    return normalized_file
+
+
+## Make callsite record
+## 构造调用点记录
+#
+#  @param file_path The source file path
+#  @param call_text The original call text
+#  @param format_api The restored API for static matching
+#  @param parameters The parameter string
+#  @param lineno The line number of callsite
+#  @param col_offset The column offset of callsite
+#  @param end_lineno The end line number of callsite
+#  @param end_col_offset The end column offset of callsite
+#  @param proj_path The project root path
+#  @return callsite record dictionary
+def makeCallsiteRecord(
+    file_path,
+    call_text,
+    format_api,
+    parameters,
+    lineno,
+    col_offset,
+    end_lineno=None,
+    end_col_offset=None,
+    proj_path=None,
+):
+    identity = CallsiteIdentity(
+        rel_path=normalizeRelPath(file_path, proj_path),
+        lineno=int(lineno),
+        col_offset=int(col_offset),
+        end_lineno=end_lineno,
+        end_col_offset=end_col_offset,
+        call_text=call_text,
+        normalized_call=normalizeCallText(call_text),
+    )
+    record = CallsiteRecord(
+        identity=identity,
+        artifact_id=identity.artifactId(),
+        format_api=format_api,
+        parameters=parameters,
+    )
+    return record.toDict()

--- a/Tool/tool.py
+++ b/Tool/tool.py
@@ -573,7 +573,7 @@ def save2txt(lst,libName,runCommand,savePath):
         fw.write(line)
         index=1
         for callAPI,subDict in dic.items():
-            displayCall=subDict.pop('Invoked API',callAPI.split('#_')[0])
+            displayCall=subDict.pop('Invoked API',callAPI)
             tempStr1=f"Invoked API #{index}: {displayCall}"
             writeLine(width,tempStr1,fw)
             fw.write('|'+' '*(width-2)+'|'+'\n')

--- a/Tool/tool.py
+++ b/Tool/tool.py
@@ -573,7 +573,7 @@ def save2txt(lst,libName,runCommand,savePath):
         fw.write(line)
         index=1
         for callAPI,subDict in dic.items():
-            displayCall=subDict.get('Invoked API',callAPI.split('#_')[0])
+            displayCall=subDict.pop('Invoked API',callAPI.split('#_')[0])
             tempStr1=f"Invoked API #{index}: {displayCall}"
             writeLine(width,tempStr1,fw)
             fw.write('|'+' '*(width-2)+'|'+'\n')

--- a/Tool/tool.py
+++ b/Tool/tool.py
@@ -15,6 +15,54 @@ import shlex
 from Path.getPath import Path
 
 
+ARTIFACT_HASH_PATTERN=re.compile(r'(?:^|__)([0-9a-f]{64})$')
+
+
+## Return artifact hash from an artifact id
+## 从运行产物id中提取hash
+#
+#  @param artifactId The artifact id
+#  @return artifact hash or empty string
+def getArtifactHash(artifactId):
+    match=ARTIFACT_HASH_PATTERN.search(artifactId)
+    if match:
+        return match.group(1)
+    return ''
+
+
+## Return readable artifact display name
+## 返回可读运行产物展示名
+#
+#  @param artifactId The artifact id
+#  @return display name
+def getArtifactDisplayName(artifactId):
+    artifactHash=getArtifactHash(artifactId)
+    if artifactHash and artifactId.endswith(artifactHash):
+        displayName=artifactId[:-len(artifactHash)].rstrip('_')
+        return displayName or artifactHash
+    return artifactId
+
+
+## Shorten artifact file name while preserving full hash
+## 缩短运行产物文件名并保留完整hash
+#
+#  @param fileName The artifact file stem
+#  @param extension The extension of the file
+#  @return fileName The shortened file name
+def shortenArtifactFileName(fileName,extension):
+    fileName=re.sub(r'[^0-9A-Za-z_.-]+','_',fileName).strip('._')
+    length=255-len(extension) if extension else 255
+    if len(fileName)<=length:
+        return fileName+extension
+    artifactHash=getArtifactHash(fileName)
+    if not artifactHash:
+        return fileName[:length]+extension
+    suffix='__'+artifactHash
+    prefixLength=max(0,length-len(suffix))
+    prefix=fileName[:prefixLength].rstrip('_')
+    return prefix+suffix+extension
+
+
 
 ## Split parameter string into list of separated parameters
 ## 将参数字符串拆分成单个的参数
@@ -27,7 +75,7 @@ from Path.getPath import Path
 #  @param separator The separator, ',' is the default value 
 #  @param space Determine whether to remove the space in the parameter string 
 #  @return parameters List of separater parameters 
-def get_parameter(p_string,separator=',',space=1):
+def getParameter(p_string,separator=',',space=1):
     #库定义的参数去空格，项目中的参数不去空格，防止出问题
     if space: #默认是去空格的
         p_string=p_string.replace(' ','') #去掉参数中的空格
@@ -107,7 +155,6 @@ def get_parameter(p_string,separator=',',space=1):
 
 
     return parameters
-
 
 
 ## Get AST for code 
@@ -403,10 +450,12 @@ def cmp(version):
 ## Normalize file name 
 ## 给文件取名字
 #
-#  @param fileName Typically, the API call string is input as the file name
+#  @param fileName Typically, the API call string or callsite artifact id is input as the file name
 #  @param extension The extension of the file
 #  @return fileName The normalized file name
 def getFileName(fileName,extension):
+    if getArtifactHash(fileName):
+        return shortenArtifactFileName(fileName,extension)
     #step1:先把fileName中的非法字符去除
     fileName=fileName.replace(' ','')
     fileName=fileName.replace('/','')
@@ -524,7 +573,8 @@ def save2txt(lst,libName,runCommand,savePath):
         fw.write(line)
         index=1
         for callAPI,subDict in dic.items():
-            tempStr1=f"Invoked API #{index}: {callAPI.split('#_')[0]}"
+            displayCall=subDict.get('Invoked API',callAPI.split('#_')[0])
+            tempStr1=f"Invoked API #{index}: {displayCall}"
             writeLine(width,tempStr1,fw)
             fw.write('|'+' '*(width-2)+'|'+'\n')
             cnt=1

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ from multiprocessing import Manager
 from Extract.getCall import getCallFunction
 from Preprocess.preprocess import codeProcess
 from Repair.repair import repairTask,validateByRun
-from Tool.tool import getAst,save2txt,loadConfig,removeParameter,getFileName,buildRunCommand,resolveConfigFilePath,resolveConfigValuePath
+from Tool.tool import getAst,save2txt,loadConfig,removeParameter,buildRunCommand,resolveConfigFilePath,resolveConfigValuePath
 from Tool.workspace import createRunWorkspace,exportRunReport,getRepoRoot,workspaceCwd
 from Change.changeAnalyze import isCompatible,addValueForAPI,updateSharedDict,querySharedDict,updateErrorLst
 
@@ -34,8 +34,17 @@ def backwardTask(args):
     # fileName=file.split('/')[-1][0:-3]
     fileName = os.path.basename(file)[:-3]
     
-    #step1:先把当前文件中指定的第三方库的API抽取出来
-    callAPIDict,_=getCallFunction(file,libName) #key是还原前的API，value是还原后的API
+    #step1:将源代码文件映射到Copy目录中
+    # tempLst=file.split('/')
+    normalized_file = file.replace('\\', '/')
+    tempLst = normalized_file.split('/')
+    pos=tempLst.index(projName)
+    realProjPath='/'.join(tempLst[0:pos+1])
+    fileRelativePath='/'.join(tempLst[pos:])
+    # copyFile='./Copy/'+fileRelativePath
+    copyFile = os.path.join('.', 'Copy', *fileRelativePath.split('/'))
+    #step2:先把当前文件中指定的第三方库的API抽取出来
+    callAPIDict,_=getCallFunction(file,libName,realProjPath) #key是artifact id，value是结构化调用点记录
     # with open(f'data/{fileName}_callAPIDict.json','w') as fw:
     os.makedirs('data', exist_ok=True)
     with open(os.path.join('data', f'{fileName}_callAPIDict.json'), 'w', encoding='utf-8') as fw:
@@ -46,43 +55,20 @@ def backwardTask(args):
         root=getAst(file) #获取当前文件的AST，便于修复使用
     except Exception as e:
         astError=e
-    #step2:将源代码文件映射到Copy目录中
-    # tempLst=file.split('/')
-    normalized_file = file.replace('\\', '/')
-    tempLst = normalized_file.split('/')
-    pos=tempLst.index(projName)
-    realProjPath='/'.join(tempLst[0:pos+1])
-    fileRelativePath='/'.join(tempLst[pos:])
-    coverageKey = '/'.join(tempLst[pos+1:]).rsplit('.', 1)[0]
-    # copyFile='./Copy/'+fileRelativePath
-    copyFile = os.path.join('.', 'Copy', *fileRelativePath.split('/'))
     invokedAPINum=len(callAPIDict)
     # errorLog=f"Report/{projName}_fixed_log.txt"
     errorLog = os.path.join('Report', f'{projName}_fixed_log.txt')
-    for key,formatAPI in callAPIDict.items():
+    for key,record in callAPIDict.items():
         errLst=[] #记录错误信息
         ansDict[key]={}
-        callAPI=key.split('#_')[0]
-        lineNum=key.split('#_')[1]
-        # 动态阶段使用调用点key区分同名API，避免不同调用行共享同一个pkl和缓存结果
-        callKey=f"{getFileName(callAPI,'')}#_{lineNum}"
+        callAPI=record['call_text']
+        lineNum=record['lineno']
+        formatAPI=record['format_api']
+        callKey=record['id']
+        ansDict[key]['Invoked API']=callAPI
         ansDict[key]['Location']=f"At Line {lineNum} in {fileRelativePath}"
-        #判断有没有覆盖有两个条件，先看是否有pkl，再看是否在coverSet中
-        # if not os.path.exists(f"Copy/pkl/{pklName}") and f"{fileName}##{lineNum}##{callAPI}".replace(' ','') not in coverSet:
-        #有些API虽然有pkl但实际上是与它同名的其它API的pkl，即它并没有被真正覆盖
-        #所以不能以pkl是否存在来判断其是否被覆盖了
-        # if f"{fileName}##{lineNum}##{callAPI}".replace(' ','') not in coverSet:
-        #     ansDict[key]['Coverage']='No'
-        #     print(f"{fileName}##{lineNum}##{callAPI}".replace(' ',''))
-        #     continue
-        
-        flag=0
-        probe = f"{coverageKey}##{lineNum}##{callAPI}".split('(')[0].replace(' ','')
-        for it in coverSet:
-            if it.replace(' ', '').startswith(probe):
-                flag=1
-                break
-        if flag==0:
+
+        if callKey not in coverSet:
             ansDict[key]['Coverage']='No' 
             continue
         


### PR DESCRIPTION
## Summary

- introduce structured callsite identity records based on source path, AST span, and normalized call text
- route runtime artifacts, manifests, dynamic match snapshots, coverage, repair validation, and shared cache lookups through callsite artifact ids
- use readable artifact file names while preserving the full SHA256 hash
- remove legacy callsite lookup fallbacks and report fallback parsing of old `call#_line` keys