### PR TITLE
Add experimental PCResolve integration for API call identification

### DIFF
--- a/Extract/getCall.py
+++ b/Extract/getCall.py
@@ -194,11 +194,21 @@ def modifyWithName(callName, withitemCallName, lineno=None):
 ## 每次传进来一个.py文件，抽取所有的调用API
 #
 #  @param filePath The .py file path
-#  @param libName The target lib name (e.g., torch) 
+#  @param libName The target lib name (e.g., torch)
 #  @param projPath The project root path
+#  @param pcresolveLookup Optional pre-built PCResolve lookup table:
+#         {filePath: {callId: CallsiteRecord_dict, ...}, ...}.
+#         When provided and filePath is present, returns the pre-computed
+#         records directly instead of re-extracting.
 #  @return Callsite record dictionaries keyed by artifact id
 #  @return 返回以运行产物id为key的调用点记录字典
-def getCallFunction(filePath,libName,projPath=None):
+def getCallFunction(filePath,libName,projPath=None,pcresolveLookup=None):
+    # If PCResolve lookup is available for this file, use it directly
+    # 若PCResolve查找表中有此文件，直接使用预计算结果
+    if pcresolveLookup is not None and filePath in pcresolveLookup:
+        records = pcresolveLookup[filePath]
+        return records, records
+
     with open(filePath,'r',encoding='UTF-8') as f:
         codeText=f.read()
         f.seek(0)

--- a/Extract/pcresolve_bridge.py
+++ b/Extract/pcresolve_bridge.py
@@ -1,0 +1,170 @@
+## @package pcresolve_bridge
+#  Bridge PCResolve analysis results into PCART CallsiteRecord format
+#
+#
+#  Converts PCResolve's cross-file ProjectAnalysis output into PCART's
+#  CallsiteRecord dictionaries, matching the return format of
+#  Extract/getCall.getCallFunction(). Supports libName filtering, caching
+#  by (projPath, libName), and graceful degradation when PCResolve is not
+#  installed.
+#  将PCResolve的跨文件ProjectAnalysis结果转换为PCART的CallsiteRecord字典，
+#  匹配Extract/getCall.getCallFunction()的返回格式。支持libName过滤、
+#  按(projPath, libName)缓存，以及PCResolve未安装时的静默降级。
+
+
+
+try:
+    from pcresolve import analyze_project as _pcresolveAnalyze
+except ImportError:
+    _pcresolveAnalyze = None
+
+_lookupCache = {}
+
+
+
+## Build a CallsiteRecord lookup table from PCResolve analysis
+## 从PCResolve分析结果构建CallsiteRecord查找表
+#
+#  Runs pcresolve.analyze_project() once per (projPath, libName) pair,
+#  filters results to calls matching the target library, and converts
+#  each ApiCall into a CallsiteRecord dict sorted by source position.
+#  Results are cached at module level for the lifetime of the process.
+#  对每个(projPath, libName)对运行一次pcresolve.analyze_project()，
+#  过滤匹配目标库的调用，将每个ApiCall转换为按源码位置排序的
+#  CallsiteRecord字典。结果在模块级别缓存，进程生命周期内有效。
+#
+#  @param projPath Absolute path to the project root
+#  @param libName Target library name (e.g. "polars", "aiofiles")
+#  @return Dict of {filePath: {callId: CallsiteRecord_dict}}.
+#          Empty dict when PCResolve is unavailable or no calls match.
+def buildCallsiteLookup(projPath, libName):
+    global _lookupCache
+    cacheKey = (projPath, libName)
+    if cacheKey in _lookupCache:
+        return _lookupCache[cacheKey]
+
+    if _pcresolveAnalyze is None:
+        _lookupCache[cacheKey] = {}
+        return _lookupCache[cacheKey]
+
+    try:
+        result = _pcresolveAnalyze(projPath)
+    except Exception:
+        _lookupCache[cacheKey] = {}
+        return _lookupCache[cacheKey]
+
+    lookup = {}
+    for call in result.all_api_calls:
+        if not _matchesLibname(call, libName):
+            continue
+
+        record = _convertApiCall(call, projPath)
+        filePath = call.file_path
+        if filePath not in lookup:
+            lookup[filePath] = {}
+        lookup[filePath][record['id']] = record
+
+    # Sort by source position within each file, matching getCallFunction ordering
+    # 在每个文件内按源码位置排序，与getCallFunction排序一致
+    for filePath in lookup:
+        lookup[filePath] = dict(sorted(
+            lookup[filePath].items(),
+            key=lambda kv: (kv[1]['lineno'], kv[1]['col_offset']),
+        ))
+
+    _lookupCache[cacheKey] = lookup
+    return lookup
+
+
+
+## Clear the module-level lookup cache
+## 清除模块级查找缓存
+#
+#  Exposed for testing. After calling _resetCache(), the next call to
+#  buildCallsiteLookup() will re-run analyze_project() instead of
+#  returning the cached result.
+#  供测试使用。调用_resetCache()后，下一次调用buildCallsiteLookup()
+#  将重新运行analyze_project()，而不是返回缓存结果。
+def _resetCache():
+    global _lookupCache
+    _lookupCache = {}
+
+
+
+## Convert a single PCResolve ApiCall to a CallsiteRecord dict
+## 将一个PCResolve ApiCall转换为CallsiteRecord字典
+#
+#  Maps ApiCall fields to CallsiteRecord fields:
+#    expression -> call_text
+#    resolved_func(parameters) -> format_api
+#    lineno/col_offset/end_lineno/end_col_offset -> source location
+#    file_path + projPath -> rel_path
+#  将ApiCall字段映射到CallsiteRecord字段：
+#    expression -> call_text
+#    resolved_func(parameters) -> format_api
+#    lineno/col_offset/end_lineno/end_col_offset -> 源码位置
+#    file_path + projPath -> rel_path
+#
+#  @param callObj pcresolve.ApiCall object
+#  @param projPath Absolute project root path for rel_path calculation
+#  @return Dict matching CallsiteRecord.toDict() format
+def _convertApiCall(callObj, projPath):
+    from Tool.callsite import makeCallsiteRecord
+
+    resolved = callObj.resolved_func or callObj.func_name or ''
+
+    return makeCallsiteRecord(
+        file_path=callObj.file_path,
+        call_text=callObj.expression,
+        format_api=f"{resolved}({callObj.parameters})" if resolved else callObj.expression,
+        parameters=callObj.parameters,
+        lineno=callObj.lineno,
+        col_offset=callObj.col_offset,
+        end_lineno=callObj.end_lineno or None,
+        end_col_offset=callObj.end_col_offset or None,
+        proj_path=projPath,
+    )
+
+
+
+## Check whether an ApiCall belongs to the target library
+## 判断一个ApiCall是否属于目标库
+#
+#  Matching is performed in three tiers:
+#    1. Exact match on top_library (PCResolve's top-level origin)
+#    2. Prefix match on resolved_func (handles submodules)
+#    3. Prefix match on func_name (fallback for unresolved calls)
+#  Local definitions and Python builtins are always excluded.
+#  匹配分为三级：
+#    1. top_library精确匹配（PCResolve的顶层来源）
+#    2. resolved_func前缀匹配（处理子模块情况）
+#    3. func_name前缀匹配（未解析调用的回退）
+#  本地定义和Python内置始终被排除。
+#
+#  @param callObj pcresolve.ApiCall object
+#  @param libName Target library name (e.g. "polars")
+#  @return True if the call matches the target library
+def _matchesLibname(callObj, libName):
+    # Exclude local definitions and Python builtins
+    # 排除本地定义和Python内置
+    if callObj.top_library in ('local', 'python'):
+        return False
+
+    # Exact match on top-level origin
+    # 顶层来源精确匹配
+    if callObj.top_library == libName:
+        return True
+
+    # Match by resolved function prefix
+    # 按解析后函数名前缀匹配
+    if callObj.resolved_func:
+        if callObj.resolved_func == libName or callObj.resolved_func.startswith(libName + '.'):
+            return True
+
+    # Fallback: match by original function name prefix
+    # 回退：按原始函数名前缀匹配
+    if callObj.func_name:
+        if callObj.func_name == libName or callObj.func_name.startswith(libName + '.'):
+            return True
+
+    return False

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@
 
 <br>
 
+## News
+
+- **2026-05-22** — Experimental [PCResolve](https://github.com/PCART-tools/PCResolve) integration: cross-file symbol-tracing replaces single-file string-matching for API call identification. Opt-in via `pcresolve>=1.0.3`; falls back to existing extraction when not installed.
+
+<br>
+
 ## What is PCART?
 
 PCART is an automated tool designed to detect and repair Python API parameter compatibility issues. It is the first to achieve a fully automated process (end-to-end) that includes `API extraction`, `code instrumentation`, `mapping`, `compatibility analysis`, and `repair and validation`. PCART specializes in addressing API compatibility issues arising from parameter `addition`, `removal`, `renaming`, `reordering`, and the `conversion of positional parameters to keyword parameters`.

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from Map.map import mapAPI
 from multiprocessing import Pool
 from multiprocessing import Manager
 from Extract.getCall import getCallFunction
+from Extract.pcresolve_bridge import buildCallsiteLookup
 from Preprocess.preprocess import codeProcess
 from Repair.repair import repairTask,validateByRun
 from Tool.tool import getAst,save2txt,loadConfig,removeParameter,buildRunCommand,resolveConfigFilePath,resolveConfigValuePath
@@ -39,7 +40,7 @@ from Change.changeAnalyze import isCompatible,addValueForAPI,updateSharedDict,qu
 #          fileRelativePath: 被处理的文件；invokedAPINum: 调用的API数量
 def backwardTask(args):
     ansDict={} #保存每个文件处理的情况
-    projName,libName,file,currentVersion,currentEnv,targetVersion,targetEnv,runCommand,runPath,lock,sharedDict,coverSet,runtimePaths=args
+    projName,libName,file,currentVersion,currentEnv,targetVersion,targetEnv,runCommand,runPath,lock,sharedDict,coverSet,runtimePaths,pcresolveLookup=args
     copyRoot=runtimePaths['copy_root']
     dataDir=runtimePaths['data_dir']
     reportDir=runtimePaths['report_dir']
@@ -55,7 +56,7 @@ def backwardTask(args):
     fileRelativePath='/'.join(tempLst[pos:])
     copyFile = os.path.join(copyRoot, *fileRelativePath.split('/'))
     #step2:先把当前文件中指定的第三方库的API抽取出来
-    callAPIDict,_=getCallFunction(file,libName,realProjPath) #key是artifact id，value是结构化调用点记录
+    callAPIDict,_=getCallFunction(file,libName,realProjPath,pcresolveLookup=pcresolveLookup) #key是artifact id，value是结构化调用点记录
     os.makedirs(dataDir, exist_ok=True)
     with open(os.path.join(dataDir, f'{fileName}_callAPIDict.json'), 'w', encoding='utf-8') as fw:
         json.dump(callAPIDict, fw, indent=4, ensure_ascii=False)
@@ -203,6 +204,9 @@ def backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,
     shutil.move(tempProjPath, os.path.join(copyRoot, f'bak_{projName}'))
 
 
+    #用PCResolve进行全项目API调用识别，结果在所有任务间复用
+    pcresolveLookup=buildCallsiteLookup(projPath,libName)
+
     #这里用进程池同时处理多个任务，但对于torch库可能会报错RuntimeError:CUDA out or memory
     #对数据库的读写需要加锁
     coverSet=set()
@@ -212,11 +216,11 @@ def backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,
             tempLst=fr.readlines()
         for it in tempLst:
             it=it.rstrip('\n').replace(' ','')
-            coverSet.add(it)  
+            coverSet.add(it)
     manager=Manager()
     lock=manager.Lock() #创建一个共享锁
     sharedDict=manager.dict() #创建一个共享字典
-    tasks=[(projName,libName,file,currentVersion,currentEnv,targetVersion,targetEnv,runCommand,runPath,lock,sharedDict,coverSet,runtimePaths) for file in filePath]
+    tasks=[(projName,libName,file,currentVersion,currentEnv,targetVersion,targetEnv,runCommand,runPath,lock,sharedDict,coverSet,runtimePaths,pcresolveLookup) for file in filePath]
     pool=Pool(processes=1)
     resultLst=pool.map(backwardTask,tasks)
     pool.close() #关闭进程池，使其不再接受新的任务

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 dill==0.3.7
+pcresolve>=1.0.3


### PR DESCRIPTION
## Summary
- Add `Extract/pcresolve_bridge.py` — a bridge module for PCResolve integration
- Integrate PCResolve into `Extract/getCall.py` and `main.py` for enhanced API call identification
- Add related dependency in `requirements.txt`
- Update README with News section for PCResolve integration