### PR TITLE
Fix PCResolve callsite instrumentation coverage

### DIFF
--- a/Extract/pcresolveBridge.py
+++ b/Extract/pcresolveBridge.py
@@ -1,4 +1,4 @@
-## @package pcresolve_bridge
+## @package pcresolveBridge
 #  Bridge PCResolve analysis results into PCART CallsiteRecord format
 #
 #

--- a/Preprocess/preprocess.py
+++ b/Preprocess/preprocess.py
@@ -562,8 +562,9 @@ def addDictSingle(callAPI,filePath,callKey):
 #  @param runFileLst The list of run files 
 #  @param libName The lib name  
 #  @param runPath The relative path of the run file 
-#  @param runCommand The run command of the project 
-def addDictAll(projPath,projName,filePath,copyRoot,runFileLst,libName,runPath,runCommand):
+#  @param runCommand The run command of the project
+#  @param pcresolveLookup Optional pre-built PCResolve lookup table
+def addDictAll(projPath,projName,filePath,copyRoot,runFileLst,libName,runPath,runCommand,pcresolveLookup=None):
     with open(filePath,'r',encoding='UTF-8') as fr:
         code=fr.read()
         fr.seek(0) #将文件指针重新定位到文件的开头
@@ -582,7 +583,10 @@ def addDictAll(projPath,projName,filePath,copyRoot,runFileLst,libName,runPath,ru
     lineno=getImportLine(codeLst)
     importDict='from recordValue import paraValueDict\nfrom recordValue import apiCoveredSet\nfrom recordValue import callsiteInfoDict\n'
     codeLst.insert(lineno,importDict)
-    _,callDict=getCallFunction(fileAbsolutePath,libName,projPath)
+    if pcresolveLookup is None:
+        _,callDict=getCallFunction(fileAbsolutePath,libName,projPath)
+    else:
+        _,callDict=getCallFunction(fileAbsolutePath,libName,projPath,pcresolveLookup=pcresolveLookup)
 
     targetLst=findAssignCall(root) #用来区分调用者是否来自赋值语句，比如a.f(), tf.f(), or self.f()
  
@@ -1056,8 +1060,9 @@ def scriptPath(scriptName):
 #  @param runPath The relative path of the run file 
 #  @param libName The lib name 
 #  @param workspace RunWorkspace object for this execution
+#  @param pcresolveLookup Optional pre-built PCResolve lookup table shared with analysis
 #  @return None
-def codeProcess(projPath,runCommand,runPath,libName,workspace):
+def codeProcess(projPath,runCommand,runPath,libName,workspace,pcresolveLookup=None):
     runtimePaths=getRuntimePaths(workspace)
     copyRoot=runtimePaths['copy_root']
     dynamicRoot=runtimePaths['dynamic_root']
@@ -1153,7 +1158,10 @@ def codeProcess(projPath,runCommand,runPath,libName,workspace):
     
     
     for file in filePath:
-        addDictAll(projPath,projName,file,copyRoot,runFileLst,libName,runPath,runCommand)
+        if pcresolveLookup is None:
+            addDictAll(projPath,projName,file,copyRoot,runFileLst,libName,runPath,runCommand)
+        else:
+            addDictAll(projPath,projName,file,copyRoot,runFileLst,libName,runPath,runCommand,pcresolveLookup=pcresolveLookup)
     
     #再对bak_proj中的运行文件进行插桩
     for file in runFileLst:

--- a/Script/recordValue.py
+++ b/Script/recordValue.py
@@ -95,8 +95,16 @@ def savePkls():
             candidateManifest['candidates'].append(candidateInfo)
         with open(os.path.join(pklDir,manifestName),'w',encoding='utf-8') as fw:
             json.dump(candidateManifest,fw,indent=4,ensure_ascii=False)
-    with open(os.path.join(pklDir,'coverSet'),'w',encoding='utf-8') as fw:
-        for it in apiCoveredSet:
+    coverSetPath=os.path.join(pklDir,'coverSet')
+    coveredSet=set(apiCoveredSet)
+    if os.path.exists(coverSetPath):
+        with open(coverSetPath,'r',encoding='utf-8') as fr:
+            for line in fr:
+                item=line.rstrip('\n').replace(' ','')
+                if item:
+                    coveredSet.add(item)
+    with open(coverSetPath,'w',encoding='utf-8') as fw:
+        for it in coveredSet:
             fw.write(it+'\n')
 
 

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ from Map.map import mapAPI
 from multiprocessing import Pool
 from multiprocessing import Manager
 from Extract.getCall import getCallFunction
-from Extract.pcresolve_bridge import buildCallsiteLookup
+from Extract.pcresolveBridge import buildCallsiteLookup
 from Preprocess.preprocess import codeProcess
 from Repair.repair import repairTask,validateByRun
 from Tool.tool import getAst,save2txt,loadConfig,removeParameter,buildRunCommand,resolveConfigFilePath,resolveConfigValuePath
@@ -40,7 +40,11 @@ from Change.changeAnalyze import isCompatible,addValueForAPI,updateSharedDict,qu
 #          fileRelativePath: 被处理的文件；invokedAPINum: 调用的API数量
 def backwardTask(args):
     ansDict={} #保存每个文件处理的情况
-    projName,libName,file,currentVersion,currentEnv,targetVersion,targetEnv,runCommand,runPath,lock,sharedDict,coverSet,runtimePaths,pcresolveLookup=args
+    if len(args)==13:
+        projName,libName,file,currentVersion,currentEnv,targetVersion,targetEnv,runCommand,runPath,lock,sharedDict,coverSet,runtimePaths=args
+        pcresolveLookup=None
+    else:
+        projName,libName,file,currentVersion,currentEnv,targetVersion,targetEnv,runCommand,runPath,lock,sharedDict,coverSet,runtimePaths,pcresolveLookup=args
     copyRoot=runtimePaths['copy_root']
     dataDir=runtimePaths['data_dir']
     reportDir=runtimePaths['report_dir']
@@ -163,7 +167,8 @@ def backwardTask(args):
 #  @param runCommand The run command of the project / 项目运行命令
 #  @param runPath   The relative path of the run file / 运行文件的相对路径
 #  @param workspace RunWorkspace object for this execution / 本次执行的运行工作区
-def backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,runCommand,runPath,workspace):
+#  @param pcresolveLookup Optional pre-built PCResolve lookup table shared with preprocessing
+def backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,runCommand,runPath,workspace,pcresolveLookup=None):
     runtimePaths=getRuntimePaths(workspace)
     copyRoot=runtimePaths['copy_root']
     dataDir=runtimePaths['data_dir']
@@ -205,7 +210,8 @@ def backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,
 
 
     #用PCResolve进行全项目API调用识别，结果在所有任务间复用
-    pcresolveLookup=buildCallsiteLookup(projPath,libName)
+    if pcresolveLookup is None:
+        pcresolveLookup=buildCallsiteLookup(projPath,libName)
 
     #这里用进程池同时处理多个任务，但对于torch库可能会报错RuntimeError:CUDA out or memory
     #对数据库的读写需要加锁
@@ -262,13 +268,15 @@ def run(config):
     print(f"Run workspace: {workspace.workspace_root}")
     print("Code preprocessing...")
 
+    pcresolveLookup=buildCallsiteLookup(projPath,libName)
+
     with workspaceCwd(workspace.workspace_root):
         #首先对代码进行预处理
-        codeProcess(projPath,runCommand,runPath,libName,workspace=workspace)
+        codeProcess(projPath,runCommand,runPath,libName,workspace=workspace,pcresolveLookup=pcresolveLookup)
         print("Code preprocess complete")
 
         #执行主逻辑
-        backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,runCommand,runPath,workspace=workspace)
+        backward(projPath,libName,currentVersion,currentEnv,targetVersion,targetEnv,runCommand,runPath,workspace=workspace,pcresolveLookup=pcresolveLookup)
 
     exportRunReport(workspace)
     print(f"Report output: {workspace.report_root}")


### PR DESCRIPTION
Build the PCResolve lookup before preprocessing and reuse it through instrumentation and compatibility analysis so both stages operate on the same callsite set.

Preserve existing coverSet entries when later single-call target-version pkl regeneration exits with an empty runtime coverage set.