### PR TITLE
Fix PCResolve 1.0.5 bridge compatibility

### DIFF
--- a/Extract/pcresolveBridge.py
+++ b/Extract/pcresolveBridge.py
@@ -53,7 +53,7 @@ def buildCallsiteLookup(projPath, libName):
         result = _analysisCache[projPath]
     else:
         try:
-            result = _pcresolveAnalyze(projPath, scope_model="v2")
+            result = _pcresolveAnalyze(projPath)
         except Exception:
             _analysisCache[projPath] = None
             _lookupCache[cacheKey] = {}


### PR DESCRIPTION
Remove the obsolete scope_model argument from analyze_project. Preserve compatibility with PCResolve 1.0.4 and 1.0.5.