### PR TITLE
Fix: improve mixed-match mapping accuracy with qualified names

### DIFF
--- a/Map/map.py
+++ b/Map/map.py
@@ -336,6 +336,8 @@ def mapAPI(callAPI,runCommand,runPath,formatAPI,projName,libName,copyFile,versio
             ans['internalPath']=dynamicMatchDict['internalPath']
         else:
             ans['internalPath']=formatAPI 
+        if 'qualifiedName' in dynamicMatchDict:
+            ans['qualifiedName']=dynamicMatchDict['qualifiedName']
     
         if 'builtin' in dynamicMatchDict['error']: #这里的内置不一定是库的内置，有可能是python内置,如何区分?
             ans['match']=fuzzymatch(formatAPI,libName,version,1) #目前只发现pytorch中把内置记录到了.pyi中

--- a/Script/dynamicMatch.py
+++ b/Script/dynamicMatch.py
@@ -68,23 +68,32 @@ for key in paraValueDict.keys():
 api=s
 err=''
 try:
-    result=str(inspect.signature(eval(api)))
+    callableObj=eval(api)
+    result=str(inspect.signature(callableObj))
     matchDict['match']=result
     matchDict['error']=''
     try:
-        internalPath=inspect.getfile(eval(api))
+        realCallable=inspect.unwrap(callableObj)
+        moduleName=getattr(realCallable,'__module__',None)
+        qualifiedName=getattr(realCallable,'__qualname__',None)
+        if isinstance(moduleName,str) and isinstance(qualifiedName,str):
+            matchDict['qualifiedName']='{}.{}'.format(moduleName,qualifiedName)
+    except Exception:
+        pass
+    try:
+        internalPath=inspect.getfile(callableObj)
         internalPath = internalPath.replace('\\', '/')
         internalPath=internalPath.split('site-packages/')[-1].replace('.py','').replace('/','.')
         matchDict['internalPath']=internalPath
-    except:
+    except Exception:
         pass
 except Exception as e:
     matchDict['match']='nullptr'
     matchDict['error']='sigError={}: {}'.format(type(e).__name__,e)
 
 
-# If dynamic matching fails, internalPath and addValue attributes are not available
-# 动态匹配若失败，则没有internalPath和addValue这两个属性
+# If dynamic matching fails, internalPath, qualifiedName and addValue attributes are not available
+# 动态匹配若失败，则没有internalPath、qualifiedName和addValue这三个属性
 fileName=getFileName(lookupKey,'_dynamicMatch.json')
 
 os.makedirs(dataDir,exist_ok=True)

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ import time
 import shutil
 import subprocess
 from Path.getPath import *
-from Map.map import mapAPI
+from Map.map import mapAPI,fuzzymatch
 from multiprocessing import Pool
 from multiprocessing import Manager
 from Extract.getCall import getCallFunction
@@ -103,7 +103,36 @@ def backwardTask(args):
         ansDict[key][f"Definition @{targetVersion} <{targetMatch['matchMethod']}>"]=str(targetMatch['match'])
         
         #step4:变更分析,若不兼容则返回需要修复的操作
-        repairLst=isCompatible(currentMatch,targetMatch) #repairLst中每个元素都是tuple
+        currentMethod=currentMatch.get('matchMethod')
+        targetMethod=targetMatch.get('matchMethod')
+        if {currentMethod,targetMethod}=={'dynamic','static'}:
+            if currentMethod=='dynamic':
+                dynamicMatchInfo=currentMatch
+                staticMatchInfo=targetMatch
+                dynamicVersion=currentVersion
+                dynamicIsCurrent=True
+            else:
+                dynamicMatchInfo=targetMatch
+                staticMatchInfo=currentMatch
+                dynamicVersion=targetVersion
+                dynamicIsCurrent=False
+
+            dynamicStaticMatch=fuzzymatch(formatAPI,libName,dynamicVersion,0)
+            staticCandidates=staticMatchInfo.get('match',{})
+            qualifiedName=dynamicMatchInfo.get('qualifiedName')
+
+            if isinstance(qualifiedName,str) and isinstance(dynamicStaticMatch,dict) and isinstance(staticCandidates,dict) \
+                    and qualifiedName in dynamicStaticMatch and qualifiedName in staticCandidates:
+                dynamicStaticCompare={'match':{qualifiedName:list(dynamicStaticMatch[qualifiedName])}}
+                staticCompare={'match':{qualifiedName:list(staticCandidates[qualifiedName])}}
+                if dynamicIsCurrent:
+                    repairLst=isCompatible(dynamicStaticCompare,staticCompare)
+                else:
+                    repairLst=isCompatible(staticCompare,dynamicStaticCompare)
+            else:
+                repairLst=None
+        else:
+            repairLst=isCompatible(currentMatch,targetMatch) #repairLst中每个元素都是tuple
         if repairLst==None:
             ansDict[key]['Compatible']="Unknown"
             if len(errLst)>0:


### PR DESCRIPTION
Record the unwrapped callable FQN during dynamic matching and propagate it through Map. When one version maps dynamically and the other statically, select the same static FQN on both sides before compatibility analysis.